### PR TITLE
[STACKED] lens keys enumerate

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -242,14 +242,9 @@ $ %s k s ibc-2 testkey`, appName, appName, appName)),
 	return cmd
 }
 
-type ChainAddress struct {
-	Chain   string
-	Address string
-}
-
 type KeyEnumeration struct {
 	KeyName   string
-	Addresses []ChainAddress
+	Addresses map[string]string
 }
 
 // keysEnumerateCmd respresents the `keys enumerate` command
@@ -285,7 +280,7 @@ $ %s k e key2`, appName, appName, appName)),
 
 			result := &KeyEnumeration{
 				KeyName:   keyName,
-				Addresses: []ChainAddress{},
+				Addresses: make(map[string]string),
 			}
 
 			for _, chain := range chains {
@@ -296,11 +291,7 @@ $ %s k e key2`, appName, appName, appName)),
 					return err
 				}
 
-				ca := ChainAddress{
-					Chain:   chain,
-					Address: address,
-				}
-				result.Addresses = append(result.Addresses, ca)
+				result.Addresses[chain] = address
 			}
 			rb, err := json.Marshal(&result)
 			if err != nil {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -243,8 +243,8 @@ $ %s k s ibc-2 testkey`, appName, appName, appName)),
 }
 
 type KeyEnumeration struct {
-	KeyName   string
-	Addresses map[string]string
+	KeyName   string            `json:"key_name"`
+	Addresses map[string]string `json:"addresses"`
 }
 
 // keysEnumerateCmd respresents the `keys enumerate` command
@@ -260,7 +260,6 @@ $ %s keys enumerate
 $ %s keys enumerate key2
 $ %s k e key2`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			cl := config.GetDefaultClient()
 			var keyName string
 			if len(args) == 0 {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -290,11 +290,9 @@ $ %s k e key2`, appName, appName, appName)),
 			}
 
 			for _, chain := range chains {
-				c := config.Chains[chain]
+				client := config.GetClient(chain)
 
-				cl.Config.AccountPrefix = c.AccountPrefix
-
-				address, err := cl.ShowAddress(keyName)
+				address, err := client.ShowAddress(keyName)
 				if err != nil {
 					return err
 				}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -9,7 +9,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -303,7 +302,7 @@ $ %s k e key2`, appName, appName, appName)),
 				}
 				result.Addresses = append(result.Addresses, ca)
 			}
-			rb, err := yaml.Marshal(&result)
+			rb, err := json.Marshal(&result)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Note: Currently stacked on top of #8

lens keys enumerate will iterate over configured chains and display the addresses for each configured chain:

```
$ lens keys enumerate
keyname: default
addresses:
- chain: bitcanna
  address: bcna1nueevlwxcux9xg8vdercas0eqmzwesgntyqzue
- chain: chihuahua
  address: chihuahua1nueevlwxcux9xg8vdercas0eqmzwesgnjpad4f
- chain: cosmoshub
  address: cosmos1nueevlwxcux9xg8vdercas0eqmzwesgn35sr5t
- chain: osmosis
  address: osmo1nueevlwxcux9xg8vdercas0eqmzwesgne0rnze
```