### PR TITLE
add(config): add chain override to cli flags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies

--- a/README.md
+++ b/README.md
@@ -7,12 +7,4 @@ Intended use cases:
 - Server side query integrations for alerting or other automation
 - Indexers and search engines
 
-This is the start of ideas around how to implement the cosmos client libraries in a seperate repo:
-
-- [ ] `lens keys` to test key integration
-- [ ] `lens query` to test query integration
-- [ ] `lens tx` to test tx integration
-- [ ] Switch `lens` from using `var config *Config` as a global variable to a `lens.Config` struct pulled out `context` in a similar manner to the way the SDK works. This should allow for generic reuse of the `cmd` package to quickly build a new client, with standard functionality.
-- [ ] How to instantiate and use the GRPC golang client? This is not currently obvious.
-- [ ] Currently we are depending on the sdk keyring libs. This is fine for now but eventually the goal is to support our own keyring implementation that is specifically for `lens`
-- [ ] Biggest TODO: is transaction generation and signing
+This is the start of ideas around how to implement the cosmos client libraries in a seperate repo.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -206,6 +206,17 @@ func initConfig(cmd *cobra.Command) error {
 		config.cl[name] = cl
 	}
 
+	// override chain if needed
+
+	if cmd.PersistentFlags().Changed("chain") {
+		defaultChain, err := cmd.PersistentFlags().GetString("chain")
+		if err != nil {
+			return err
+		}
+
+		config.DefaultChain = defaultChain
+	}
+
 	// validate configuration
 	if err = validateConfig(config); err != nil {
 		fmt.Println("Error parsing chain config:", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,11 +25,12 @@ import (
 )
 
 var (
-	homePath    string
-	debug       bool
-	config      *Config
-	defaultHome = os.ExpandEnv("$HOME/.lens")
-	appName     = "lens"
+	homePath       string
+	overridenChain string
+	debug          bool
+	config         *Config
+	defaultHome    = os.ExpandEnv("$HOME/.lens")
+	appName        = "lens"
 )
 
 // NewRootCmd returns the root command for relayer.
@@ -58,6 +59,11 @@ func NewRootCmd() *cobra.Command {
 	// --debug flag
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug output")
 	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+		panic(err)
+	}
+
+	rootCmd.PersistentFlags().StringVar(&overridenChain, "chain", "", "override default chain")
+	if err := viper.BindPFlag("chain", rootCmd.PersistentFlags().Lookup("chain")); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Simple change, allows to override chain name for use in subcommands `tx`, `tendermint`, etc.

Usage:
`--chain <chain_name_in_config>`

If `--chain` is not defined, it'll default to value in config