### PR TITLE
add(dist): add distribution queries

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -7,6 +7,7 @@ import (
 	querytypes "github.com/cosmos/cosmos-sdk/types/query"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	transfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 )
 
@@ -100,6 +101,82 @@ func (cc *ChainClient) QueryBalance(address sdk.AccAddress, showDenoms bool) (sd
 		}
 	}
 	return out, nil
+}
+
+func (cc *ChainClient) QueryDistributionCommission(address string) (*disttypes.ValidatorAccumulatedCommission, error) {
+	request := disttypes.QueryValidatorCommissionRequest{
+		ValidatorAddress: address,
+	}
+	res, err := disttypes.NewQueryClient(cc).ValidatorCommission(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Commission, nil
+}
+
+func (cc *ChainClient) QueryDistributionCommunityPool() (sdk.DecCoins, error) {
+	request := disttypes.QueryCommunityPoolRequest{}
+
+	res, err := disttypes.NewQueryClient(cc).CommunityPool(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Pool, err
+}
+
+func (cc *ChainClient) QueryDistributionParams() (*disttypes.Params, error) {
+	res, err := disttypes.NewQueryClient(cc).Params(context.Background(), &disttypes.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Params, nil
+}
+
+func (cc *ChainClient) QueryDistributionRewards(delegatorAddress string, validatorAddress string) (sdk.DecCoins, error) {
+	request := disttypes.QueryDelegationRewardsRequest{
+		DelegatorAddress: delegatorAddress,
+		ValidatorAddress: validatorAddress,
+	}
+	res, err := disttypes.NewQueryClient(cc).DelegationRewards(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Rewards, nil
+}
+
+func (cc *ChainClient) QueryDistributionSlashes(validatorAddress string) ([]disttypes.ValidatorSlashEvent, error) {
+	request := disttypes.QueryValidatorSlashesRequest{
+		ValidatorAddress: validatorAddress,
+	}
+
+	res, err := disttypes.NewQueryClient(cc).ValidatorSlashes(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Slashes, nil
+}
+
+func (cc *ChainClient) QueryDistributionValidatorRewards(validatorAddress string) (*disttypes.ValidatorOutstandingRewards, error) {
+	request := disttypes.QueryValidatorOutstandingRewardsRequest{
+		ValidatorAddress: validatorAddress,
+	}
+
+	res, err := disttypes.NewQueryClient(cc).ValidatorOutstandingRewards(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Rewards, nil
 }
 
 func DefaultPageRequest() *querytypes.PageRequest {

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -64,7 +64,7 @@ func queryDistributionCommissionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commission [validator]",
 		Args:  cobra.ExactArgs(1),
-		Short: "query a specific validator's comission",
+		Short: "query a specific validator's commission",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl := config.GetDefaultClient()
 			address := args[0]

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func getDistributionQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "distribution",
+		Short: "Query things about a chain's distribution module",
+	}
+
+	cmd.AddCommand(
+		queryDistributionParamsCmd(),
+		queryDistributionCommunityPoolCmd(),
+		queryDistributionRewardsCmd(),
+		queryDistributionSlashesCmd(),
+		queryDistributionValidatorRewardsCmd(),
+		queryDistributionCommissionCmd(),
+	)
+
+	return cmd
+}
+
+func queryDistributionParamsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "query things about a chain's distribution params",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			params, err := cl.QueryDistributionParams()
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(params)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryDistributionCommunityPoolCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "community-pool",
+		Short: "query things about a chain's community pool",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			pool, err := cl.QueryDistributionCommunityPool()
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(pool)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryDistributionCommissionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "commission [validator]",
+		Args:  cobra.ExactArgs(1),
+		Short: "query a specific validator's comission",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			address := args[0]
+			commission, err := cl.QueryDistributionCommission(address)
+
+			if err != nil {
+				return err
+			}
+
+			cl.PrintObject(commission)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryDistributionRewardsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rewards",
+		Short: "query things about a delegator's rewards",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			delegatorAddress := args[0]
+			validatorAddress := args[1]
+
+			pool, err := cl.QueryDistributionRewards(delegatorAddress, validatorAddress)
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(pool)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryDistributionSlashesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "slashes",
+		Short: "query things about a validator's slashes on a chain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			address := args[0]
+
+			slashes, err := cl.QueryDistributionSlashes(address)
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(slashes)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryDistributionValidatorRewardsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validator-outstanding-rewards [address]",
+		Short: "query things about a validator's (and all their delegators) outstanding rewards on a chain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			address := args[0]
+
+			rewards, err := cl.QueryDistributionValidatorRewards(address)
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(rewards)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -11,12 +11,12 @@ func getDistributionQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		queryDistributionParamsCmd(),
+		queryDistributionCommissionCmd(),
 		queryDistributionCommunityPoolCmd(),
+		queryDistributionParamsCmd(),
 		queryDistributionRewardsCmd(),
 		queryDistributionSlashesCmd(),
 		queryDistributionValidatorRewardsCmd(),
-		queryDistributionCommissionCmd(),
 	)
 
 	return cmd

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -20,6 +20,7 @@ func queryCmd() *cobra.Command {
 		queryBalanceCmd(),
 		queryAccountCmd(),
 		getAuthQueryCmd(),
+		getDistributionQueryCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
Add standard Cosmos SDK queries for the distribution module:

```
Usage:
  lens query distribution [command]

Available Commands:
  commission                    query a specific validator's comission
  community-pool                query things about a chain's community pool
  params                        query things about a chain's distribution params
  rewards                       query things about a delegator's rewards
  slashes                       query things about a validator's slashes on a chain
  validator-outstanding-rewards query things about a validator's (and all their delegators) outstanding rewards on a chain

```