### PR TITLE
Add an output flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lens.exe
+.idea/

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -193,7 +193,6 @@ func initConfig(cmd *cobra.Command) error {
 	}
 
 	// override chain if needed
-
 	if cmd.PersistentFlags().Changed("chain") {
 		defaultChain, err := cmd.PersistentFlags().GetString("chain")
 		if err != nil {
@@ -201,6 +200,18 @@ func initConfig(cmd *cobra.Command) error {
 		}
 
 		config.DefaultChain = defaultChain
+	}
+
+	if cmd.PersistentFlags().Changed("output") {
+		output, err := cmd.PersistentFlags().GetString("output")
+		if err != nil {
+			return err
+		}
+
+		// Should output be a global configuration item?
+		for chain, _ := range config.Chains {
+			config.Chains[chain].OutputFormat = output
+		}
 	}
 
 	// validate configuration

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -118,9 +118,8 @@ func getDistributionParamsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cl.PrintObject(params)
 
-			return nil
+			return cl.PrintObject(params)
 		},
 	}
 
@@ -137,9 +136,8 @@ func getDistributionCommunityPoolCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cl.PrintObject(pool)
 
-			return nil
+			return cl.PrintObject(pool)
 		},
 	}
 
@@ -154,14 +152,13 @@ func getDistributionCommissionCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl := config.GetDefaultClient()
 			address := args[0]
-			commission, err := cl.QueryDistributionCommission(address)
 
+			commission, err := cl.QueryDistributionCommission(address)
 			if err != nil {
 				return err
 			}
 
-			cl.PrintObject(commission)
-			return nil
+			return cl.PrintObject(commission)
 		},
 	}
 
@@ -182,9 +179,8 @@ func getDistributionRewardsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cl.PrintObject(pool)
 
-			return nil
+			return cl.PrintObject(pool)
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,11 @@ func NewRootCmd() *cobra.Command {
 		panic(err)
 	}
 
+	rootCmd.PersistentFlags().StringP("output", "o", "json", "output format (json, json-indent, yaml)")
+	if err := viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output")); err != nil {
+		panic(err)
+	}
+
 	rootCmd.PersistentFlags().StringVar(&overridenChain, "chain", "", "override default chain")
 	if err := viper.BindPFlag("chain", rootCmd.PersistentFlags().Lookup("chain")); err != nil {
 		panic(err)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -2,11 +2,11 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// TxCommand regesters a new tx command.
+// TxCommand registers a new tx command.
 func txCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx",
-		Short: "query things about a chain",
+		Short: "broadcast transactions to a chain",
 	}
 
 	cmd.AddCommand(bankTxCmd())


### PR DESCRIPTION
Adds an `--output` flag to _somewhat_ handle #19 . Since `output` is an item on every ChainConfig, when the flag is set it updates all of them for that current invocation.

Threw in a couple really small fixes for bugs I encountered while running the tool. This project is a great idea. 