### PR TITLE
add(feegrant): add feegrant tx and query commands

### DIFF
--- a/client/chain_client.go
+++ b/client/chain_client.go
@@ -79,9 +79,9 @@ func (cc *ChainClient) PrintTxResponse(res *sdk.TxResponse) error {
 func (cc *ChainClient) HandleAndPrintMsgSend(res *sdk.TxResponse, err error) error {
 	if err != nil {
 		if res != nil {
-			return fmt.Errorf("failed to withdraw rewards: code(%d) msg(%s)", res.Code, res.Logs)
+			return fmt.Errorf("failed to send tx: code(%d) msg(%s)", res.Code, res.Logs)
 		}
-		return fmt.Errorf("failed to withdraw rewards: err(%w)", err)
+		return fmt.Errorf("failed to send tx: err(%w)", err)
 	}
 	return cc.PrintTxResponse(res)
 }

--- a/client/feegrant.go
+++ b/client/feegrant.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
+	feetypes "github.com/cosmos/cosmos-sdk/x/feegrant"
+)
+
+func (cc *ChainClient) QueryFeeGrants(address sdk.AccAddress, pageReq *querytypes.PageRequest) ([]*feetypes.Grant, error) {
+	addr, err := cc.EncodeBech32AccAddr(address)
+	if err != nil {
+		return nil, err
+	}
+
+	request := feetypes.QueryAllowancesRequest{
+		Grantee:    addr,
+		Pagination: pageReq,
+	}
+
+	res, err := feetypes.NewQueryClient(cc).Allowances(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.GetAllowances(), nil
+}
+
+func (cc *ChainClient) QueryFeeGrant(granteeAddress sdk.AccAddress, granterAddress sdk.AccAddress) (*feetypes.Grant, error) {
+	granteeAddr, err := cc.EncodeBech32AccAddr(granteeAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	granterAddr, err := cc.EncodeBech32AccAddr(granterAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	request := feetypes.QueryAllowanceRequest{
+		Grantee: granteeAddr,
+		Granter: granterAddr,
+	}
+
+	res, err := feetypes.NewQueryClient(cc).Allowance(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Allowance, nil
+}

--- a/client/feegrant.go
+++ b/client/feegrant.go
@@ -8,7 +8,7 @@ import (
 	feetypes "github.com/cosmos/cosmos-sdk/x/feegrant"
 )
 
-func (cc *ChainClient) QueryFeeGrants(address sdk.AccAddress, pageReq *querytypes.PageRequest) ([]*feetypes.Grant, error) {
+func (cc *ChainClient) QueryFeeGrants(address sdk.AccAddress, pageReq *querytypes.PageRequest) (*feetypes.QueryAllowancesResponse, error) {
 	addr, err := cc.EncodeBech32AccAddr(address)
 	if err != nil {
 		return nil, err
@@ -25,10 +25,10 @@ func (cc *ChainClient) QueryFeeGrants(address sdk.AccAddress, pageReq *querytype
 		return nil, err
 	}
 
-	return res.GetAllowances(), nil
+	return res, nil
 }
 
-func (cc *ChainClient) QueryFeeGrant(granteeAddress sdk.AccAddress, granterAddress sdk.AccAddress) (*feetypes.Grant, error) {
+func (cc *ChainClient) QueryFeeGrant(granteeAddress sdk.AccAddress, granterAddress sdk.AccAddress) (*feetypes.QueryAllowanceResponse, error) {
 	granteeAddr, err := cc.EncodeBech32AccAddr(granteeAddress)
 	if err != nil {
 		return nil, err
@@ -50,5 +50,5 @@ func (cc *ChainClient) QueryFeeGrant(granteeAddress sdk.AccAddress, granterAddre
 		return nil, err
 	}
 
-	return res.Allowance, nil
+	return res, nil
 }

--- a/cmd/feegrant.go
+++ b/cmd/feegrant.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -96,8 +95,6 @@ func feegrantQueryGrantCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("did not find wallet %s", keyNameOrAddress)
 			}
-
-			fmt.Println(args[0])
 
 			granteeAddr, err = cl.DecodeBech32AccAddr(args[0])
 			if err != nil {
@@ -251,7 +248,6 @@ func feegrantRevokeFeeGrantCmd() *cobra.Command {
 		Short: "Grant fee allowance to an address",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("a")
 			var (
 				granterAddr sdk.AccAddress
 				granteeAddr sdk.AccAddress
@@ -271,7 +267,6 @@ func feegrantRevokeFeeGrantCmd() *cobra.Command {
 			}
 
 			msg := feegrant.NewMsgRevokeAllowance(granterAddr, granteeAddr)
-			fmt.Println(reflect.TypeOf(msg))
 
 			// sends tx but fails due to gas
 

--- a/cmd/feegrant.go
+++ b/cmd/feegrant.go
@@ -53,15 +53,6 @@ func feegrantQueryGrantsCmd() *cobra.Command {
 				return err
 			}
 
-			// FIXME: if anyone can tell me why JSON output without this doesn't work gets a 5 OSMO tip
-			// FIXME: seems like there should be no side effects with using the MarshalProto function, but thats not the
-			for grant := range grants {
-				_, err := cl.MarshalProto(grants[grant])
-				if err != nil {
-					return err
-				}
-			}
-
 			return cl.PrintObject(grants)
 		},
 	}
@@ -116,24 +107,25 @@ func feegrantQueryGrantCmd() *cobra.Command {
 
 func feegrantFeeGrantCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "grant grantee",
+		Use:   "grant grantee [granter] spend-limit ",
 		Short: "Grant fee allowance to an address",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(1, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				granterAddr sdk.AccAddress
-				granteeAddr sdk.AccAddress
+				granterAddr types.AccAddress
+				granteeAddr types.AccAddress
 				err         error
 			)
 
 			cl := config.GetDefaultClient()
-			key, _ := cmd.Flags().GetString(FlagFrom)
-			granterAddr, err = cl.AccountFromKeyOrAddress(key)
+
+			granterAddr, err = cl.AccountFromKeyOrAddress(args[0])
+
 			if err != nil {
-				return err
+				return fmt.Errorf("did not find wallet %s", args[0])
 			}
 
-			granteeAddr, err = cl.DecodeBech32AccAddr(args[0])
+			granteeAddr, err = cl.DecodeBech32AccAddr(args[1])
 			if err != nil {
 				return err
 			}

--- a/cmd/feegrant.go
+++ b/cmd/feegrant.go
@@ -1,0 +1,293 @@
+package cmd
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	"github.com/spf13/cobra"
+)
+
+// flag for feegrant module
+const (
+	FlagExpiration  = "expiration"
+	FlagPeriod      = "period"
+	FlagPeriodLimit = "period-limit"
+	FlagSpendLimit  = "spend-limit"
+	FlagAllowedMsgs = "allowed-messages"
+)
+
+func feegrantQueryGrantsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "grants [grantee]",
+		Short: "query things about a grantee",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			pageReq, err := ReadPageRequest(cmd.Flags())
+
+			if err != nil {
+				return err
+			}
+
+			var address types.AccAddress
+			var keyNameOrAddress string
+
+			if len(args) == 0 {
+				keyNameOrAddress = cl.Config.Key
+			} else {
+				keyNameOrAddress = args[0]
+			}
+
+			address, err = cl.AccountFromKeyOrAddress(keyNameOrAddress)
+
+			if err != nil {
+				return err
+			}
+
+			grants, err := cl.QueryFeeGrants(address, pageReq)
+			if err != nil {
+				return err
+			}
+
+			// FIXME: if anyone can tell me why JSON output without this doesn't work gets a 5 OSMO tip
+			// FIXME: seems like there should be no side effects with using the MarshalProto function, but thats not the
+			for grant := range grants {
+				_, err := cl.MarshalProto(grants[grant])
+				if err != nil {
+					return err
+				}
+			}
+
+			return cl.PrintObject(grants)
+		},
+	}
+
+	return paginationFlags(cmd)
+}
+
+func feegrantQueryGrantCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "grant grantee [granter]",
+		Short: "query things about a single grant",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+
+			var (
+				granterAddr      types.AccAddress
+				granteeAddr      types.AccAddress
+				err              error
+				keyNameOrAddress string
+			)
+
+			if len(args) == 1 {
+				keyNameOrAddress = cl.Config.Key
+			} else {
+				keyNameOrAddress = args[1]
+			}
+
+			granterAddr, err = cl.AccountFromKeyOrAddress(keyNameOrAddress)
+
+			if err != nil {
+				return fmt.Errorf("did not find wallet %s", keyNameOrAddress)
+			}
+
+			fmt.Println(args[0])
+
+			granteeAddr, err = cl.DecodeBech32AccAddr(args[0])
+			if err != nil {
+				return err
+			}
+
+			grant, err := cl.QueryFeeGrant(granteeAddr, granterAddr)
+
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintObject(grant)
+		},
+	}
+
+	return cmd
+}
+
+func feegrantFeeGrantCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "grant grantee",
+		Short: "Grant fee allowance to an address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				granterAddr sdk.AccAddress
+				granteeAddr sdk.AccAddress
+				err         error
+			)
+
+			cl := config.GetDefaultClient()
+			key, _ := cmd.Flags().GetString(FlagFrom)
+			granterAddr, err = cl.AccountFromKeyOrAddress(key)
+			if err != nil {
+				return err
+			}
+
+			granteeAddr, err = cl.DecodeBech32AccAddr(args[0])
+			if err != nil {
+				return err
+			}
+
+			spendLimit, err := cmd.Flags().GetString(FlagSpendLimit)
+			if err != nil {
+				return err
+			}
+
+			spendLimitCoins, err := sdk.ParseCoinsNormalized(spendLimit)
+			if err != nil {
+				return err
+			}
+
+			exp, err := cmd.Flags().GetString(FlagExpiration)
+			if err != nil {
+				return err
+			}
+
+			basicGrant := feegrant.BasicAllowance{
+				SpendLimit: spendLimitCoins,
+			}
+
+			var expiresAtTime time.Time
+			if exp != "" {
+				expiresAtTime, err = time.Parse(time.RFC3339, exp)
+				if err != nil {
+					return err
+				}
+
+				basicGrant.Expiration = &expiresAtTime
+			}
+
+			var grant feegrant.FeeAllowanceI
+			grant = &basicGrant
+
+			periodClock, err := cmd.Flags().GetInt64(FlagPeriod)
+			if err != nil {
+				return err
+			}
+
+			periodLimitVal, err := cmd.Flags().GetString(FlagPeriodLimit)
+			if err != nil {
+				return err
+			}
+
+			if periodClock > 0 || periodLimitVal != "" {
+				periodLimit, err := sdk.ParseCoinsNormalized(periodLimitVal)
+				if err != nil {
+					return err
+				}
+
+				if periodClock <= 0 {
+					return fmt.Errorf("period clock was not set")
+				}
+
+				if periodLimit == nil {
+					return fmt.Errorf("period limit was not set")
+				}
+
+				periodReset := getPeriodReset(periodClock)
+				if exp != "" && periodReset.Sub(expiresAtTime) > 0 {
+					return fmt.Errorf("period (%d) cannot reset after expiration (%v)", periodClock, exp)
+				}
+
+				periodic := feegrant.PeriodicAllowance{
+					Basic:            basicGrant,
+					Period:           getPeriod(periodClock),
+					PeriodReset:      getPeriodReset(periodClock),
+					PeriodSpendLimit: periodLimit,
+					PeriodCanSpend:   periodLimit,
+				}
+
+				grant = &periodic
+			}
+
+			allowedMsgs, err := cmd.Flags().GetStringSlice(FlagAllowedMsgs)
+			if err != nil {
+				return err
+			}
+
+			if len(allowedMsgs) > 0 {
+				grant, err = feegrant.NewAllowedMsgAllowance(grant, allowedMsgs)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			msg, err := feegrant.NewMsgGrantAllowance(grant, granterAddr, granteeAddr)
+			if err != nil {
+				return err
+			}
+
+			return cl.HandleAndPrintMsgSend(cl.SendMsg(cmd.Context(), msg))
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().StringSlice(FlagAllowedMsgs, []string{}, "Set of allowed messages for fee allowance")
+	cmd.Flags().String(FlagExpiration, "", "The RFC 3339 timestamp after which the grant expires for the user")
+	cmd.Flags().String(FlagSpendLimit, "", "Spend limit specifies the max limit can be used, if not mentioned there is no limit")
+	cmd.Flags().Int64(FlagPeriod, 0, "period specifies the time duration(in seconds) in which period_limit coins can be spent before that allowance is reset (ex: 3600)")
+	cmd.Flags().String(FlagPeriodLimit, "", "period limit specifies the maximum number of coins that can be spent in the period")
+
+	return cmd
+}
+
+func feegrantRevokeFeeGrantCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke grantee",
+		Short: "Grant fee allowance to an address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("a")
+			var (
+				granterAddr sdk.AccAddress
+				granteeAddr sdk.AccAddress
+				err         error
+			)
+
+			cl := config.GetDefaultClient()
+			key, _ := cmd.Flags().GetString(FlagFrom)
+			granterAddr, err = cl.AccountFromKeyOrAddress(key)
+			if err != nil {
+				return err
+			}
+
+			granteeAddr, err = cl.DecodeBech32AccAddr(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := feegrant.NewMsgRevokeAllowance(granterAddr, granteeAddr)
+			fmt.Println(reflect.TypeOf(msg))
+
+			// sends tx but fails due to gas
+
+			return cl.HandleAndPrintMsgSend(cl.SendMsg(cmd.Context(), &msg))
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func getPeriodReset(duration int64) time.Time {
+	return time.Now().Add(getPeriod(duration))
+}
+
+func getPeriod(duration int64) time.Duration {
+	return time.Duration(duration) * time.Second
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -102,8 +102,8 @@ func feegrantQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-	// feegrantGrantsCmd(),
-	// feegrantFeeGrantsCmd(),
+		feegrantQueryGrantCmd(),
+		feegrantQueryGrantsCmd(),
 	)
 
 	return cmd

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -94,8 +94,8 @@ func feegrantTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-	// feegrantFeeGrantCmd(),
-	// feegrantRevoteFeeGrantCmd(),
+		feegrantFeeGrantCmd(),
+		feegrantRevokeFeeGrantCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
PR still has two issues (not very related to feegrant themselves):
* Can't decode the list of grants (check FIXME)
* Revoke fee grant runs out of gas for some reason

```
go run main.go tx feegrant grant cosmos1lrwqvjeu2eq0wv97d2uka6lzthn7ra6kqxep99 --from test
```

https://www.mintscan.io/cosmos/txs/0414C7F679FC44CDA1EE223E2A318DFBADE0AB24453AAD484F2778A368314638

```
go run main.go q feegrant grant cosmos1lrwqvjeu2eq0wv97d2uka6lzthn7ra6kqxep99
{"granter":"cosmos13a26ypvztxclryjngwj2zhal2kv0eq78zvcdys","grantee":"cosmos1lrwqvjeu2eq0wv97d2uka6lzthn7ra6kqxep99","allowance":{"@type":"/cosmos.feegrant.v1beta1.BasicAllowance","spend_limit":[],"expiration":null}}
````

```
go run main.go q feegrant grants cosmos1lrwqvjeu2eq0wv97d2uka6lzthn7ra6kqxep99
[{"granter":"cosmos13a26ypvztxclryjngwj2zhal2kv0eq78zvcdys","grantee":"cosmos1lrwqvjeu2eq0wv97d2uka6lzthn7ra6kqxep99","allowance":{"@type":"/cosmos.feegrant.v1beta1.BasicAllowance","spend_limit":[],"expiration":null}}]
```
