### PR TITLE
Add Slashing Query Functions and Commands

### DIFF
--- a/client/slashing.go
+++ b/client/slashing.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
-func (cc *ChainClient) QuerySlashingSigningInfo(publicKey string, _ *querytypes.PageRequest) (*types.QuerySigningInfoResponse, error) {
+func (cc *ChainClient) QuerySlashingSigningInfo(publicKey string) (*types.QuerySigningInfoResponse, error) {
 	var pk cryptotypes.PubKey
 	if err := cc.Codec.Marshaler.UnmarshalInterfaceJSON([]byte(publicKey), &pk); err != nil {
 		return nil, err

--- a/client/slashing.go
+++ b/client/slashing.go
@@ -9,14 +9,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
-func (cc *ChainClient) QuerySlashingSigningInfo(publicKey string) (*types.QuerySigningInfoResponse, error) {
-	var pk cryptotypes.PubKey
-	if err := cc.Codec.Marshaler.UnmarshalInterfaceJSON([]byte(publicKey), &pk); err != nil {
-		return nil, err
-	}
-
-	consAddr := sdk.ConsAddress(pk.Address())
-	params := &types.QuerySigningInfoRequest{ConsAddress: consAddr.String()}
+func (cc *ChainClient) QuerySlashingSigningInfo(publicKey cryptotypes.PubKey) (*types.QuerySigningInfoResponse, error) {
+	params := &types.QuerySigningInfoRequest{ConsAddress: sdk.ConsAddress(publicKey.Address()).String()}
 	res, err := types.NewQueryClient(cc).SigningInfo(context.Background(), params)
 	if err != nil {
 		return nil, err

--- a/client/slashing.go
+++ b/client/slashing.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"context"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+)
+
+func (cc *ChainClient) QuerySlashingSigningInfo(publicKey string, _ *querytypes.PageRequest) (*types.QuerySigningInfoResponse, error) {
+	var pk cryptotypes.PubKey
+	if err := cc.Codec.Marshaler.UnmarshalInterfaceJSON([]byte(publicKey), &pk); err != nil {
+		return nil, err
+	}
+
+	consAddr := sdk.ConsAddress(pk.Address())
+	params := &types.QuerySigningInfoRequest{ConsAddress: consAddr.String()}
+	res, err := types.NewQueryClient(cc).SigningInfo(context.Background(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (cc *ChainClient) QuerySlashingSigningInfos(pageReq *querytypes.PageRequest) (*types.QuerySigningInfosResponse, error) {
+	res, err := types.NewQueryClient(cc).SigningInfos(context.Background(),
+		&types.QuerySigningInfosRequest{Pagination: pageReq})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (cc *ChainClient) QuerySlashingParams() (*types.QueryParamsResponse, error) {
+	res, err := types.NewQueryClient(cc).Params(context.Background(), &types.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -142,9 +142,9 @@ func slashingQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-	// slashingSigningInfoCmd(),
-	// slashingParamsCmd(),
-	// slashingSigningInfosCmd(),
+		slashingSigningInfoCmd(),
+		slashingSigningInfosCmd(),
+		slashingParamsCmd(),
 	)
 
 	return cmd

--- a/cmd/slashing.go
+++ b/cmd/slashing.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"strings"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+func slashingParamsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query the current slashing parameters",
+		Args:  cobra.NoArgs,
+		Long: strings.TrimSpace(`Query genesis parameters for the slashing module:
+
+$ <appd> query slashing params
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := config.GetDefaultClient()
+			result, err := client.QuerySlashingParams()
+			if err != nil {
+				return err
+			}
+			return client.PrintObject(result)
+		},
+	}
+	return cmd
+}
+
+func slashingSigningInfoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signing-info [validator-conspub]",
+		Short: "Query a validator's signing information",
+		Long: strings.TrimSpace(`Use a validators' consensus public key to find the signing-info for that validator:
+
+$ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="}'
+`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := config.GetDefaultClient()
+			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+			result, err := client.QuerySlashingSigningInfo(args[0], pageReq)
+			if err != nil {
+				return err
+			}
+
+			return client.PrintObject(result)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func slashingSigningInfosCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signing-infos",
+		Short: "Query signing information of all validators",
+		Long: strings.TrimSpace(`signing infos of validators:
+
+$ <appd> query slashing signing-infos
+`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := config.GetDefaultClient()
+			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+			result, err := client.QuerySlashingSigningInfos(pageReq)
+			if err != nil {
+				return err
+			}
+
+			return client.PrintObject(result)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "signing infos")
+
+	return cmd
+}

--- a/cmd/slashing.go
+++ b/cmd/slashing.go
@@ -40,11 +40,7 @@ $ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := config.GetDefaultClient()
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
-			if err != nil {
-				return err
-			}
-			result, err := client.QuerySlashingSigningInfo(args[0], pageReq)
+			result, err := client.QuerySlashingSigningInfo(args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/slashing.go
+++ b/cmd/slashing.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -40,7 +42,13 @@ $ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := config.GetDefaultClient()
-			result, err := client.QuerySlashingSigningInfo(args[0])
+
+			var pk cryptotypes.PubKey
+			if err := client.Codec.Marshaler.UnmarshalInterfaceJSON([]byte(args[0]), &pk); err != nil {
+				return err
+			}
+
+			result, err := client.QuerySlashingSigningInfo(pk)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Add the `slashing` query functions to the Client. 
Create CLI commands for the three `slashing` query functions