### PR TITLE
[WIP] Querying Proposals

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -9,6 +10,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govTypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	transfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 )
 
@@ -190,6 +192,25 @@ func (cc *ChainClient) QueryDistributionValidatorRewards(validatorAddress string
 	}
 
 	return &res.Rewards, nil
+}
+
+func (cc *ChainClient) QueryGovernanceProposals(proposalStatus govTypes.ProposalStatus, voter string, depositor string, pageReq *querytypes.PageRequest) ([]govTypes.Proposal, error) {
+	request := govTypes.QueryProposalsRequest{
+		ProposalStatus: proposalStatus,
+		Voter:          voter,
+		Depositor:      depositor,
+		Pagination:     pageReq,
+	}
+
+	res, err := govTypes.NewQueryClient(cc).Proposals(context.Background(), &request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("%v\n", res.Proposals)
+
+	return res.Proposals, nil
 }
 
 func DefaultPageRequest() *querytypes.PageRequest {

--- a/client/query.go
+++ b/client/query.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -194,7 +193,7 @@ func (cc *ChainClient) QueryDistributionValidatorRewards(validatorAddress string
 	return &res.Rewards, nil
 }
 
-func (cc *ChainClient) QueryGovernanceProposals(proposalStatus govTypes.ProposalStatus, voter string, depositor string, pageReq *querytypes.PageRequest) ([]govTypes.Proposal, error) {
+func (cc *ChainClient) QueryGovernanceProposals(proposalStatus govTypes.ProposalStatus, voter string, depositor string, pageReq *querytypes.PageRequest) (*govTypes.QueryProposalsResponse, error) {
 	request := govTypes.QueryProposalsRequest{
 		ProposalStatus: proposalStatus,
 		Voter:          voter,
@@ -208,9 +207,7 @@ func (cc *ChainClient) QueryGovernanceProposals(proposalStatus govTypes.Proposal
 		return nil, err
 	}
 
-	fmt.Printf("%v\n", res.Proposals)
-
-	return res.Proposals, nil
+	return res, nil
 }
 
 func DefaultPageRequest() *querytypes.PageRequest {

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	FlagProposals = "proposals"
+)
+
+func getGovernanceProposalsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposals",
+		Short: "query things about a chain's proposals",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+
+			pageReq, err := ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params, err := cl.QueryGovernanceProposals(types.StatusVotingPeriod, "", "", pageReq)
+			if err != nil {
+				return err
+			}
+			cl.PrintObject(params)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -19,7 +19,7 @@ func getGovernanceProposalsCmd() *cobra.Command {
 		Use:   "proposals",
 		Short: "query things about a chain's proposals",
 		Long: strings.TrimSpace(
-			`Query for a paginated proposals that match optional filters:
+			`Query for paginated proposals that match optional filters:
 Example:
 $ lens query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 $ lens query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -5,10 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	FlagProposals = "proposals"
-)
-
 func getGovernanceProposalsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proposals",
@@ -25,11 +21,9 @@ func getGovernanceProposalsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cl.PrintObject(params)
-
-			return nil
+			return cl.PrintObject(params)
 		},
 	}
 
-	return cmd
+	return paginationFlags(cmd)
 }

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -17,11 +17,11 @@ func getGovernanceProposalsCmd() *cobra.Command {
 				return err
 			}
 
-			params, err := cl.QueryGovernanceProposals(types.StatusVotingPeriod, "", "", pageReq)
+			proposalsResponse, err := cl.QueryGovernanceProposals(types.StatusVotingPeriod, "", "", pageReq)
 			if err != nil {
 				return err
 			}
-			return cl.PrintObject(params)
+			return cl.PrintObject(proposalsResponse)
 		},
 	}
 

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -1,29 +1,80 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/version"
+	govClient "github.com/cosmos/cosmos-sdk/x/gov/client/utils"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/spf13/cobra"
+)
+
+var (
+	flagDepositor = "depostior"
+	flagVoter     = "voter"
+	flagStatus    = "status"
 )
 
 func getGovernanceProposalsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proposals",
 		Short: "query things about a chain's proposals",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query for a paginated proposals that match optional filters:
+Example:
+$ %s query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ %s query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ %s query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
+$ %s query gov proposals --page=2 --limit=100
+`, version.AppName, version.AppName, version.AppName, version.AppName,
+			),
+		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl := config.GetDefaultClient()
+
+			bechDepositorAddr, _ := cmd.Flags().GetString(flagDepositor)
+			bechVoterAddr, _ := cmd.Flags().GetString(flagVoter)
+			strProposalStatus, _ := cmd.Flags().GetString(flagStatus)
+
+			var proposalStatus types.ProposalStatus
+
+			if len(bechDepositorAddr) != 0 {
+				_, err := cl.DecodeBech32ValAddr(bechDepositorAddr)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(bechVoterAddr) != 0 {
+				_, err := cl.DecodeBech32ValAddr(bechVoterAddr)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(strProposalStatus) != 0 {
+				proposalStatus1, err := types.ProposalStatusFromString(govClient.NormalizeProposalStatus(strProposalStatus))
+				proposalStatus = proposalStatus1
+				if err != nil {
+					return err
+				}
+			}
 
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}
 
-			proposalsResponse, err := cl.QueryGovernanceProposals(types.StatusVotingPeriod, "", "", pageReq)
+			proposalsResponse, err := cl.QueryGovernanceProposals(proposalStatus, bechDepositorAddr, bechVoterAddr, pageReq)
 			if err != nil {
 				return err
 			}
 			return cl.PrintObject(proposalsResponse)
 		},
 	}
-
+	cmd.Flags().String(flagDepositor, "", "(optional) filter by proposals deposited on by depositor")
+	cmd.Flags().String(flagVoter, "", "(optional) filter by proposals voted on by voted")
+	cmd.Flags().String(flagStatus, "", "(optional) filter proposals by proposal status, status: deposit_period/voting_period/passed/rejected")
 	return paginationFlags(cmd)
 }

--- a/cmd/governance.go
+++ b/cmd/governance.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/cosmos/cosmos-sdk/version"
 	govClient "github.com/cosmos/cosmos-sdk/x/gov/client/utils"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/spf13/cobra"
@@ -21,14 +19,12 @@ func getGovernanceProposalsCmd() *cobra.Command {
 		Use:   "proposals",
 		Short: "query things about a chain's proposals",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Query for a paginated proposals that match optional filters:
+			`Query for a paginated proposals that match optional filters:
 Example:
-$ %s query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
-$ %s query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
-$ %s query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
-$ %s query gov proposals --page=2 --limit=100
-`, version.AppName, version.AppName, version.AppName, version.AppName,
-			),
+$ lens query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ lens query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ lens query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
+$ lens query gov proposals --page=2 --limit=100`,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl := config.GetDefaultClient()

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -16,6 +16,7 @@ func queryCmd() *cobra.Command {
 		authQueryCmd(),
 		bankQueryCmd(),
 		distributionQueryCmd(),
+		governanceQueryCmd(),
 	)
 
 	return cmd
@@ -67,6 +68,20 @@ func distributionQueryCmd() *cobra.Command {
 		getDistributionRewardsCmd(),
 		getDistributionSlashesCmd(),
 		getDistributionValidatorRewardsCmd(),
+	)
+
+	return cmd
+}
+
+func governanceQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "governance",
+		Aliases: []string{"gov", "govern", "g"},
+		Short:   "Query things about a chain's governance module",
+	}
+
+	cmd.AddCommand(
+		getGovernanceProposalsCmd(),
 	)
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
 	github.com/tendermint/tendermint v0.34.14
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.43.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -96,7 +97,7 @@ require (
 	github.com/tendermint/tm-db v0.6.4 // indirect
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
-	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -918,7 +918,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1015,7 +1014,6 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f h1:w6wWR0H+nyVpbSAQbzVEIACVyr/h8l/BEkY6Sokc7Eg=
 golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
Working for default proposals 
```
Query for a paginated proposals that match optional filters:
Example:
$ lens query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
$ lens query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
$ lens query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
$ lens query gov proposals --page=2 --limit=100

Usage:
  lens query governance proposals [flags]

Flags:
      --count-total        count total number of records in objects to query for (default true)
      --depostior string   (optional) filter by proposals deposited on by depositor
  -h, --help               help for proposals
      --limit uint         pagination limit of objects to query for (default 100)
      --offset uint        pagination offset of objects to query for
      --page uint          pagination page of objects to query for. This sets offset to a multiple of limit (default 1)
      --page-key string    pagination page-key of objects to query for
      --reverse            results are sorted in descending order
      --status string      (optional) filter proposals by proposal status, status: deposit_period/voting_period/passed/rejected
      --voter string       (optional) filter by proposals voted on by voted

Global Flags:
      --chain string   override default chain
  -d, --debug          debug output
      --home string    set home directory (default "C:\\Users\\joeab/.lens")
```

For example:
```
$ lens q gov proposals --chain regen | jq .
{
  "proposals": [
    {
      "proposal_id": "8",
      "content": {
        "@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
        "title": "Credit Class Creator - Regen Registry",
        "description": "This is a parameter change proposal to add a multisig address for Regen Registry, currently managed by members of Regen Network Development (RND), to the list of allowed credit class creators. The RND staff are applying on behalf of Regen Registry, which we envision will become the first community governed registry program, owned and operated by experts committed to ecological regeneration.\n\nFor more information, see the long-form proposal: https://github.com/regen-network/governance/tree/main/proposals/2021-12-regen-registry-credit-class-creator",
        "changes": [
          {
            "subspace": "ecocredit",
            "key": "AllowedClassCreators",
            "value": "[\n                \"regen123a7e9gvgm53zvswc6daq7c85xtzt8263lgasm\"\n            ]"
          }
        ]
      },
      "status": "PROPOSAL_STATUS_VOTING_PERIOD",
      "final_tally_result": {
        "yes": "0",
        "abstain": "0",
        "no": "0",
        "no_with_veto": "0"
      },
      "submit_time": "2021-12-23T23:16:48.618057670Z",
      "deposit_end_time": "2022-01-06T23:16:48.618057670Z",
      "total_deposit": [
        {
          "denom": "uregen",
          "amount": "200000000"
        }
      ],
      "voting_start_time": "2021-12-24T01:40:20.924789916Z",
      "voting_end_time": "2022-01-07T01:40:20.924789916Z"
    }
  ],
  "pagination": {
    "next_key": null,
    "total": "1"
  }
}
```

- [x] Handle flags
- [ ] Handle Customs Proposal types.
