### PR TITLE
Kill the dreaded Bech32 errors :axe: 

### DIFF
--- a/client/provider.go
+++ b/client/provider.go
@@ -183,7 +183,7 @@ func (cc *ChainClient) CreateClient(clientState ibcexported.ClientState, dstHead
 		return nil, err
 	}
 
-	return NewCosmosMessage(msg), msg.ValidateBasic()
+	return NewCosmosMessage(msg), nil
 }
 
 func (cc *ChainClient) SubmitMisbehavior( /*TBD*/ ) (provider.RelayerMessage, error) {
@@ -216,7 +216,7 @@ func (cc *ChainClient) UpdateClient(srcClientId string, dstHeader ibcexported.He
 	if err != nil {
 		return nil, err
 	}
-	return NewCosmosMessage(msg), msg.ValidateBasic()
+	return NewCosmosMessage(msg), nil
 }
 
 func (cc *ChainClient) ConnectionOpenInit(srcClientId, dstClientId string, dstHeader ibcexported.Header) ([]provider.RelayerMessage, error) {
@@ -247,7 +247,7 @@ func (cc *ChainClient) ConnectionOpenInit(srcClientId, dstClientId string, dstHe
 		Signer:       acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ConnectionOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]provider.RelayerMessage, error) {
@@ -304,7 +304,7 @@ func (cc *ChainClient) ConnectionOpenTry(dstQueryProvider provider.QueryProvider
 		Signer:          acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ConnectionOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]provider.RelayerMessage, error) {
@@ -353,7 +353,7 @@ func (cc *ChainClient) ConnectionOpenAck(dstQueryProvider provider.QueryProvider
 		Signer:          acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ConnectionOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]provider.RelayerMessage, error) {
@@ -386,7 +386,7 @@ func (cc *ChainClient) ConnectionOpenConfirm(dstQueryProvider provider.QueryProv
 		Signer:       acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ChannelOpenInit(srcClientId, srcConnId, srcPortId, srcVersion, dstPortId string, order chantypes.Order, dstHeader ibcexported.Header) ([]provider.RelayerMessage, error) {
@@ -418,7 +418,7 @@ func (cc *ChainClient) ChannelOpenInit(srcClientId, srcConnId, srcPortId, srcVer
 		Signer: acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ChannelOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
@@ -463,7 +463,7 @@ func (cc *ChainClient) ChannelOpenTry(dstQueryProvider provider.QueryProvider, d
 		Signer:              acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ChannelOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]provider.RelayerMessage, error) {
@@ -500,7 +500,7 @@ func (cc *ChainClient) ChannelOpenAck(dstQueryProvider provider.QueryProvider, d
 		Signer:                acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ChannelOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChanId string) ([]provider.RelayerMessage, error) {
@@ -534,7 +534,7 @@ func (cc *ChainClient) ChannelOpenConfirm(dstQueryProvider provider.QueryProvide
 		Signer:      acc,
 	}
 
-	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, msg.ValidateBasic()
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
 func (cc *ChainClient) ChannelCloseInit(srcPortId, srcChanId string) (provider.RelayerMessage, error) {

--- a/client/provider.go
+++ b/client/provider.go
@@ -645,6 +645,9 @@ func (cc *ChainClient) InjectTrustedFields(header ibcexported.Header, dst provid
 
 	// TODO: this is likely a source of off by 1 errors but may be impossible to change? Maybe this is the
 	// place where we need to fix the upstream query proof issue?
+	// TODO removed the +1 here for now to test removing these errors
+	// Error: TrustedHeight {4 9032785} must be less than header height {4 9032785}: invalid header height
+	// Maybe add back?
 	var trustedHeader *tmclient.Header
 	if err := retry.Do(func() error {
 		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight))

--- a/client/provider.go
+++ b/client/provider.go
@@ -114,7 +114,6 @@ func (cc *ChainClient) Timeout() string {
 // Address returns the chains configured address as a string
 func (cc *ChainClient) Address() (string, error) {
 	var (
-		//acc sdk.AccAddress
 		err  error
 		info keyring.Info
 	)
@@ -127,11 +126,6 @@ func (cc *ChainClient) Address() (string, error) {
 		return "", err
 	}
 
-	//if acc, err = cc.GetKeyAddress(); err != nil {
-	//	return "", err
-	//}
-	//fmt.Println(acc.String())
-	//return acc.String(), nil
 	return out, err
 }
 
@@ -140,12 +134,14 @@ func (cc *ChainClient) TrustingPeriod() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	integer, _ := math.Modf(res.UnbondingTime.Hours() * 0.7)
 	trustingStr := fmt.Sprintf("%vh", integer)
 	tp, err := time.ParseDuration(trustingStr)
 	if err != nil {
 		return 0, nil
 	}
+
 	return tp, nil
 }
 

--- a/client/provider.go
+++ b/client/provider.go
@@ -630,7 +630,7 @@ func (cc *ChainClient) InjectTrustedFields(header ibcexported.Header, dst provid
 	}
 
 	// retrieve dst client from src chain
-	// this is the client that will updated
+	// this is the client that will be updated
 	cs, err := dst.QueryClientState(0, dstClientId)
 	if err != nil {
 		return nil, err
@@ -647,7 +647,7 @@ func (cc *ChainClient) InjectTrustedFields(header ibcexported.Header, dst provid
 	// place where we need to fix the upstream query proof issue?
 	var trustedHeader *tmclient.Header
 	if err := retry.Do(func() error {
-		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight) + 1)
+		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight))
 		th, ok := tmpHeader.(*tmclient.Header)
 		if !ok {
 			err = errors.New("non-tm client header")

--- a/client/provider.go
+++ b/client/provider.go
@@ -645,12 +645,9 @@ func (cc *ChainClient) InjectTrustedFields(header ibcexported.Header, dst provid
 
 	// TODO: this is likely a source of off by 1 errors but may be impossible to change? Maybe this is the
 	// place where we need to fix the upstream query proof issue?
-	// TODO removed the +1 here for now to test removing these errors
-	// Error: TrustedHeight {4 9032785} must be less than header height {4 9032785}: invalid header height
-	// Maybe add back?
 	var trustedHeader *tmclient.Header
 	if err := retry.Do(func() error {
-		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight))
+		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight + 1))
 		th, ok := tmpHeader.(*tmclient.Header)
 		if !ok {
 			err = errors.New("non-tm client header")

--- a/client/query.go
+++ b/client/query.go
@@ -92,7 +92,7 @@ func (cc *ChainClient) QueryBalance(keyName string) (sdk.Coins, error) {
 // QueryBalanceWithAddress returns the amount of coins in the relayer account with address as input
 // TODO add pagination support
 func (cc *ChainClient) QueryBalanceWithAddress(address string) (sdk.Coins, error) {
-	addr, err := sdk.AccAddressFromBech32(address)
+	addr, err := cc.DecodeBech32AccAddr(address)
 	if err != nil {
 		return nil, err
 	}

--- a/client/query.go
+++ b/client/query.go
@@ -73,20 +73,20 @@ func (cc *ChainClient) QueryTxs(page, limit int, events []string) ([]*ctypes.Res
 // QueryBalance returns the amount of coins in the relayer account
 func (cc *ChainClient) QueryBalance(keyName string) (sdk.Coins, error) {
 	var (
-		addr sdk.AccAddress
+		addr string
 		err  error
 	)
 	if keyName == "" {
-		addr, err = cc.GetKeyAddress()
+		addr, err = cc.Address()
 	} else {
 		cc.Config.Key = keyName
-		addr, err = cc.GetKeyAddress()
+		addr, err = cc.Address()
 	}
 
 	if err != nil {
 		return nil, err
 	}
-	return cc.QueryBalanceWithAddress(addr.String())
+	return cc.QueryBalanceWithAddress(addr)
 }
 
 // QueryBalanceWithAddress returns the amount of coins in the relayer account with address as input

--- a/client/query.go
+++ b/client/query.go
@@ -194,8 +194,11 @@ func (cc *ChainClient) QueryClientStateResponse(height int64, srcClientId string
 		return nil, err
 	}
 
-	clientStateRes := clienttypes.NewQueryClientStateResponse(anyClientState, proofBz, proofHeight)
-	return clientStateRes, nil
+	return &clienttypes.QueryClientStateResponse{
+		ClientState: anyClientState,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
 }
 
 // QueryClientState retrieves the latest consensus state for a client in state at a given height

--- a/client/query.go
+++ b/client/query.go
@@ -92,13 +92,14 @@ func (cc *ChainClient) QueryBalance(keyName string) (sdk.Coins, error) {
 // QueryBalanceWithAddress returns the amount of coins in the relayer account with address as input
 // TODO add pagination support
 func (cc *ChainClient) QueryBalanceWithAddress(address string) (sdk.Coins, error) {
-	addr, err := cc.DecodeBech32AccAddr(address)
-	if err != nil {
-		return nil, err
-	}
+	//addr, err := cc.DecodeBech32AccAddr(address)
+	//if err != nil {
+	//	return nil, err
+	//}
 
-	p := bankTypes.NewQueryAllBalancesRequest(addr, DefaultPageRequest())
+	//p := bankTypes.NewQueryAllBalancesRequest(addr, DefaultPageRequest())
 
+	p := &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: DefaultPageRequest()}
 	queryClient := bankTypes.NewQueryClient(cc)
 
 	res, err := queryClient.AllBalances(context.Background(), p)

--- a/client/relayer_packets.go
+++ b/client/relayer_packets.go
@@ -61,22 +61,24 @@ func (rp relayMsgTimeout) Msg(src provider.ChainProvider, srcPortId, srcChanId, 
 	if err != nil {
 		return nil, err
 	}
-	msg := chantypes.NewMsgTimeout(
-		chantypes.NewPacket(
-			rp.packetData,
-			rp.seq,
-			srcPortId,
-			srcChanId,
-			dstPortId,
-			dstChanId,
-			rp.timeout,
-			rp.timeoutStamp,
-		),
-		rp.seq,
-		rp.dstRecvRes.Proof,
-		rp.dstRecvRes.ProofHeight,
-		addr,
-	)
+
+	msg := &chantypes.MsgTimeout{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         srcPortId,
+			SourceChannel:      srcChanId,
+			DestinationPort:    dstPortId,
+			DestinationChannel: dstChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		ProofUnreceived:  rp.dstRecvRes.Proof,
+		ProofHeight:      rp.dstRecvRes.ProofHeight,
+		NextSequenceRecv: rp.seq,
+		Signer:           addr,
+	}
+
 	return NewCosmosMessage(msg), nil
 }
 
@@ -141,22 +143,22 @@ func (rp relayMsgRecvPacket) Msg(src provider.ChainProvider, srcPortId, srcChanI
 		return nil, err
 	}
 
-	packet := chantypes.NewPacket(
-		rp.packetData,
-		rp.seq,
-		dstPortId,
-		dstChanId,
-		srcPortId,
-		srcChanId,
-		rp.timeout,
-		rp.timeoutStamp,
-	)
-	msg := chantypes.NewMsgRecvPacket(
-		packet,
-		rp.dstComRes.Proof,
-		rp.dstComRes.ProofHeight,
-		addr,
-	)
+	msg := &chantypes.MsgRecvPacket{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         dstPortId,
+			SourceChannel:      dstChanId,
+			DestinationPort:    srcPortId,
+			DestinationChannel: srcChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		ProofCommitment: rp.dstComRes.Proof,
+		ProofHeight:     rp.dstComRes.ProofHeight,
+		Signer:          addr,
+	}
+
 	return NewCosmosMessage(msg), nil
 }
 
@@ -195,22 +197,23 @@ func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanId
 		return nil, err
 	}
 
-	msg := chantypes.NewMsgAcknowledgement(
-		chantypes.NewPacket(
-			rp.packetData,
-			rp.seq,
-			srcPortId,
-			srcChanId,
-			dstPortId,
-			dstChanId,
-			rp.timeout,
-			rp.timeoutStamp,
-		),
-		rp.ack,
-		rp.dstComRes.Proof,
-		rp.dstComRes.ProofHeight,
-		addr,
-	)
+	msg := &chantypes.MsgAcknowledgement{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         srcPortId,
+			SourceChannel:      srcChanId,
+			DestinationPort:    dstPortId,
+			DestinationChannel: dstChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		Acknowledgement: rp.ack,
+		ProofAcked:      rp.dstComRes.Proof,
+		ProofHeight:     rp.dstComRes.ProofHeight,
+		Signer:          addr,
+	}
+
 	return NewCosmosMessage(msg), nil
 }
 


### PR DESCRIPTION
This PR addresses various address encoding/decoding issues, as well as outstanding calls to ibc-go and the sdk, which were causing more of the Bech32 errors that were present in the go-relayer