### PR TITLE
Move chain registry code into `client/` directory

### DIFF
--- a/client/chain_registry/asset_list.go
+++ b/client/chain_registry/asset_list.go
@@ -1,4 +1,4 @@
-package chain_info
+package chain_registry
 
 type AssetList struct {
 	Schema  string `json:"$schema"`

--- a/client/chain_registry/chain_info.go
+++ b/client/chain_registry/chain_info.go
@@ -1,4 +1,4 @@
-package chain_info
+package chain_registry
 
 import (
 	"context"

--- a/client/chain_registry/chain_info_test.go
+++ b/client/chain_registry/chain_info_test.go
@@ -1,4 +1,4 @@
-package chain_info
+package chain_registry
 
 import (
 	"testing"

--- a/client/chain_registry/chain_registry.go
+++ b/client/chain_registry/chain_registry.go
@@ -1,11 +1,7 @@
 package chain_registry
 
-import (
-	"github.com/strangelove-ventures/lens/internal/chain_info"
-)
-
 type ChainRegistry interface {
-	GetChain(name string) (chain_info.ChainInfo, error)
+	GetChain(name string) (ChainInfo, error)
 	ListChains() ([]string, error)
 	SourceLink() string
 }

--- a/client/chain_registry/cosmos_github_registry.go
+++ b/client/chain_registry/cosmos_github_registry.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
-	"github.com/strangelove-ventures/lens/internal/chain_info"
 )
 
 type CosmosGithubRegistry struct{}
@@ -39,7 +38,7 @@ func (c CosmosGithubRegistry) ListChains() ([]string, error) {
 	return chains, nil
 }
 
-func (c CosmosGithubRegistry) GetChain(name string) (chain_info.ChainInfo, error) {
+func (c CosmosGithubRegistry) GetChain(name string) (ChainInfo, error) {
 	client := github.NewClient(http.DefaultClient)
 
 	chainFileName := path.Join(name, "chain.json")
@@ -50,17 +49,17 @@ func (c CosmosGithubRegistry) GetChain(name string) (chain_info.ChainInfo, error
 		chainFileName,
 		&github.RepositoryContentGetOptions{})
 	if err != nil || res.StatusCode != 200 {
-		return chain_info.ChainInfo{}, errors.Wrap(err, fmt.Sprintf("error fetching %s", chainFileName))
+		return ChainInfo{}, errors.Wrap(err, fmt.Sprintf("error fetching %s", chainFileName))
 	}
 
 	content, err := fileContent.GetContent()
 	if err != nil {
-		return chain_info.ChainInfo{}, err
+		return ChainInfo{}, err
 	}
 
-	var result chain_info.ChainInfo
+	var result ChainInfo
 	if err := json.Unmarshal([]byte(content), &result); err != nil {
-		return chain_info.ChainInfo{}, err
+		return ChainInfo{}, err
 	}
 
 	return result, nil

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/strangelove-ventures/lens/client/chain_registry"
 	"log"
 	"os"
 	"os/exec"
@@ -9,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/lens/internal/chain_registry"
 )
 
 func chainsCmd() *cobra.Command {


### PR DESCRIPTION
Moving the chain-registry related code into the `client/` directory and making sure the functions/methods there are public for use in outside repos.

Closes #47 