### PR TITLE
handle additional rpc endpoint formats

### DIFF
--- a/client/chain_registry/chain_info.go
+++ b/client/chain_registry/chain_info.go
@@ -66,14 +66,24 @@ func (c ChainInfo) GetAllRPCEndpoints() (out []string, err error) {
 		if err != nil {
 			return nil, err
 		}
+
 		var port string
-		if u.Scheme == "https" {
-			port = "443"
+		if u.Port() == "" {
+			switch u.Scheme {
+			case "https":
+				port = "443"
+			case "http":
+				port = "80"
+			default:
+				return nil, fmt.Errorf("invalid or unsupported url scheme: %v", u.Scheme)
+			}
 		} else {
 			port = u.Port()
 		}
-		out = append(out, fmt.Sprintf("%s://%s:%s", u.Scheme, u.Hostname(), port))
+
+		out = append(out, fmt.Sprintf("%s://%s:%s%s", u.Scheme, u.Hostname(), port, u.Path))
 	}
+
 	return
 }
 

--- a/client/chain_registry/chain_info_test.go
+++ b/client/chain_registry/chain_info_test.go
@@ -1,6 +1,7 @@
 package chain_registry
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,36 @@ func TestGetAllRPCEndpoints(t *testing.T) {
 			expectedEndpoints: []string{"http://test.com:26657"},
 			expectedError:     nil,
 		},
+		"endpoint with TLS and with path": {
+			chainInfo:         ChainInfoWithRPCEndpoint("https://test.com/rpc"),
+			expectedEndpoints: []string{"https://test.com:443/rpc"},
+			expectedError:     nil,
+		},
+		"endpoint with TLS and non-standard port": {
+			chainInfo:         ChainInfoWithRPCEndpoint("https://test.com:8443"),
+			expectedEndpoints: []string{"https://test.com:8443"},
+			expectedError:     nil,
+		},
+		"proxied endpoint with TLS and non-standard port": {
+			chainInfo:         ChainInfoWithRPCEndpoint("https://test.com:8443/rpc"),
+			expectedEndpoints: []string{"https://test.com:8443/rpc"},
+			expectedError:     nil,
+		},
+		"proxied endpoint without TLS and without path": {
+			chainInfo:         ChainInfoWithRPCEndpoint("http://test.com"),
+			expectedEndpoints: []string{"http://test.com:80"},
+			expectedError:     nil,
+		},
+		"proxied endpoint without TLS and with path": {
+			chainInfo:         ChainInfoWithRPCEndpoint("http://test.com/rpc"),
+			expectedEndpoints: []string{"http://test.com:80/rpc"},
+			expectedError:     nil,
+		},
+		"unsupported or invalid url scheme error": {
+			chainInfo:         ChainInfoWithRPCEndpoint("ftp://test.com/rpc"),
+			expectedEndpoints: nil,
+			expectedError:     fmt.Errorf("invalid or unsupported url scheme: ftp"),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -29,7 +60,7 @@ func TestGetAllRPCEndpoints(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			endpoints, err := tc.chainInfo.GetAllRPCEndpoints()
 			require.Equal(t, tc.expectedError, err)
-			require.Equal(t, endpoints, tc.expectedEndpoints)
+			require.Equal(t, tc.expectedEndpoints, endpoints)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #65

This adds handling for the additional possible endpoint formats:
1. endpoint with TLS and path e.g. `https://test.com/rpc`
2. proxied endpoint without TLS and no path e.g. `http://test.com`
3. proxied endpoint without TLS and with path e.g. `http://test.com/rpc`

Not sure why anyone would add a proxy but not add TLS (2 & 3) but hey who am I to judge ¯\_(ツ)_/¯



