### PR TITLE
WIP: Adding retries in the Provider calls for creating clients

### DIFF
--- a/client/chain_client.go
+++ b/client/chain_client.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/relayer/relayer/provider"
 	"github.com/gogo/protobuf/proto"
 	"github.com/tendermint/tendermint/libs/log"
 	provtypes "github.com/tendermint/tendermint/light/provider"
@@ -94,6 +96,45 @@ func (cc *ChainClient) HandleAndPrintMsgSend(res *sdk.TxResponse, err error) err
 		return fmt.Errorf("failed to withdraw rewards: err(%w)", err)
 	}
 	return cc.PrintTxResponse(res)
+}
+
+// LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
+func (cc *ChainClient) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+	if cc.Config.Debug {
+		cc.Log(fmt.Sprintf("- [%s] -> failed sending transaction:", cc.ChainId()))
+		for _, msg := range msgs {
+			_ = cc.PrintObject(msg)
+		}
+	}
+
+	if err != nil {
+		cc.Logger.Error(fmt.Errorf("- [%s] -> err(%v)", cc.ChainId(), err).Error())
+		if res == nil {
+			return
+		}
+	}
+
+	if res.Code != 0 && res.Data != "" {
+		cc.Log(fmt.Sprintf("✘ [%s]@{%d} - msg(%s) err(%d:%s)", cc.ChainId(), res.Height, getMsgTypes(msgs), res.Code, res.Data))
+	}
+
+	if cc.Config.Debug && res != nil {
+		cc.Log("- transaction response:")
+		_ = cc.PrintObject(res)
+	}
+}
+
+func getMsgTypes(msgs []provider.RelayerMessage) string {
+	var out string
+	for i, msg := range msgs {
+		out += fmt.Sprintf("%d:%s,", i, msg.Type())
+	}
+	return strings.TrimSuffix(out, ",")
+}
+
+// LogSuccessTx take the transaction and the messages to create it and logs the appropriate data
+func (cc *ChainClient) LogSuccessTx(res *sdk.TxResponse, msgs []provider.RelayerMessage) {
+	cc.Logger.Info(fmt.Sprintf("✔ [%s]@{%d} - msg(%s) hash(%s)", cc.ChainId(), res.Height, getMsgTypes(msgs), res.TxHash))
 }
 
 func (cc *ChainClient) PrintObject(res interface{}) error {

--- a/client/tx.go
+++ b/client/tx.go
@@ -118,11 +118,11 @@ func (cc *ChainClient) SendMessages(msgs []provider.RelayerMessage) (*provider.R
 	// NOTE: error is nil, logic should use the returned error to determine if the
 	// transaction was successfully executed.
 	if rlyRes.Code != 0 {
-		//cc.LogFailedTx(res, err, CosmosMsgs(msgs...))
+		cc.LogFailedTx(rlyRes, err, msgs)
 		return rlyRes, false, fmt.Errorf("transaction failed with code: %d", res.Code)
 	}
 
-	//cc.LogSuccessTx(res, CosmosMsgs(msgs...))
+	cc.LogSuccessTx(res, msgs)
 	return rlyRes, true, nil
 }
 

--- a/client/tx.go
+++ b/client/tx.go
@@ -42,10 +42,19 @@ func (ccc *ChainClientConfig) SignMode() signing.SignMode {
 	return signMode
 }
 
+// SendMessage attempts to sign, encode & send a RelayerMessage
+// This is used extensively in the relayer as an extension of the Provider interface
 func (cc *ChainClient) SendMessage(msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 	return cc.SendMessages([]provider.RelayerMessage{msg})
 }
 
+// SendMessages attempts to sign, encode, & send a slice of RelayerMessages
+// This is used extensively in the relayer as an extension of the Provider interface
+//
+// NOTE: An error is returned if there was an issue sending the transaction. A successfully sent, but failed
+// transaction will not return an error. If a transaction is successfully sent, the result of the execution
+// of that transaction will be logged. A boolean indicating if a transaction was successfully
+// sent and executed successfully is returned.
 func (cc *ChainClient) SendMessages(msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 	// Query account details
 	txf, err := cc.PrepareFactory(cc.TxFactory())


### PR DESCRIPTION
Most of the calls required in creating new IBC clients lacked proper retries so when we encounter node performance issues or unusually high latency it becomes nearly impossible to create clients.

Adding retries throughout the call stack for this process should ensure that clients can be successfully created even when nodes are under high usage