### PR TITLE
keysever proto

### DIFF
--- a/proto/keyserver/v1/keyserver.proto
+++ b/proto/keyserver/v1/keyserver.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package keyserver;
+
+// AccountKeyService is a key service for storing cosmos account keys
+// these keys are assumed to be `secp256k1` keys
+service AccountKeyService {
+    rpc NewKey(NewKeyRequest) returns (NewKeyResponse);
+    rpc Sign(SignRequest) returns (SignResponse);
+    rpc PubKey(PubKeyRequest) returns (PubKeyResponse);
+}
+
+message NewKeyRequest {
+    string name = 1;
+    string derivation_path = 2;
+}
+
+message NewKeyResponse {
+    bytes pub_key = 1;
+    string error = 2;
+}
+
+message SignRequest {
+    bytes sign_data = 1;
+    string chain_id = 2;
+    int64 account_number = 3;
+    int64 sequence = 4;
+}
+
+message SignResponse {
+    bytes signature = 1;
+    string error = 2;
+}
+
+message PubKeyRequest {
+    string name = 1;
+}
+
+
+message PubKeyResponse {
+    bytes pub_key = 1;
+    string error = 2;
+}


### PR DESCRIPTION
Next steps if we want to do this in the lens repo:
- [ ] Decide on final API and features for the keyserver
- [ ] generate go stubs for types and GRPC interfaces
- [ ] create a client implementation in a top level `keyring` package that will be used by the `client` package to sign
- [ ] create a sample `file` server implementation to be used as the default