### PR TITLE
Fix staticcheck warnings

### DIFF
--- a/client/encoding.go
+++ b/client/encoding.go
@@ -4,7 +4,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -28,7 +27,7 @@ func MakeCodec(moduleBasics []module.AppModuleBasic) Codec {
 }
 
 func MakeCodecConfig() Codec {
-	interfaceRegistry := cdctypes.NewInterfaceRegistry()
+	interfaceRegistry := types.NewInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
 	return Codec{
 		InterfaceRegistry: interfaceRegistry,

--- a/client/query.go
+++ b/client/query.go
@@ -3,9 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	querytypes "github.com/cosmos/cosmos-sdk/types/query"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -173,7 +173,7 @@ func (cc *ChainClient) QueryDistributionRewards(ctx context.Context, delegatorAd
 }
 
 // QueryDistributionSlashes returns all slashes of a validator, optionally pass the start and end height
-func (cc *ChainClient) QueryDistributionSlashes(ctx context.Context, validatorAddress sdk.ValAddress, startHeight, endHeight uint64, pageReq *querytypes.PageRequest) (*distTypes.QueryValidatorSlashesResponse, error) {
+func (cc *ChainClient) QueryDistributionSlashes(ctx context.Context, validatorAddress sdk.ValAddress, startHeight, endHeight uint64, pageReq *query.PageRequest) (*distTypes.QueryValidatorSlashesResponse, error) {
 	valAddr, err := cc.EncodeBech32ValAddr(validatorAddress)
 	if err != nil {
 		return nil, err
@@ -212,8 +212,8 @@ func (cc *ChainClient) QueryDenomsMetadata(ctx context.Context, pageReq *query.P
 	return bankTypes.NewQueryClient(cc).DenomsMetadata(ctx, &bankTypes.QueryDenomsMetadataRequest{Pagination: pageReq})
 }
 
-func DefaultPageRequest() *querytypes.PageRequest {
-	return &querytypes.PageRequest{
+func DefaultPageRequest() *query.PageRequest {
+	return &query.PageRequest{
 		Key:        []byte(""),
 		Offset:     0,
 		Limit:      1000,

--- a/client/query/bank.go
+++ b/client/query/bank.go
@@ -11,8 +11,7 @@ import (
 
 // BalanceWithAddressRPC returns the balance of all coins for a single account.
 func BalanceWithAddressRPC(q *Query, address string) (*bankTypes.QueryAllBalancesResponse, error) {
-	var req *bankTypes.QueryAllBalancesRequest
-	req = &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: q.Options.Pagination}
+	req := &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: q.Options.Pagination}
 	queryClient := bankTypes.NewQueryClient(q.Client)
 	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/client/query/staking.go
+++ b/client/query/staking.go
@@ -2,11 +2,12 @@ package query
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"google.golang.org/grpc/metadata"
-	"strconv"
-	"time"
 )
 
 // Delegation returns the delegations to a particular validator
@@ -21,7 +22,7 @@ func Delegation(q *Query, delegator, validator string) (*stakingTypes.Delegation
 	strHeight := strconv.Itoa(int(q.Options.Height))
 	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
 	defer cancel()
-	res, err := queryClient.Delegation(context.Background(), params)
+	res, err := queryClient.Delegation(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -185,7 +185,7 @@ func initConfig(cmd *cobra.Command) error {
 		}
 
 		// Should output be a global configuration item?
-		for chain, _ := range config.Chains {
+		for chain := range config.Chains {
 			config.Chains[chain].OutputFormat = output
 		}
 	}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -18,13 +18,16 @@ func queryCmd() *cobra.Command {
 		bankQueryCmd(),
 		distributionQueryCmd(),
 		stakingQueryCmd(),
-		/* Enabled these when commands are available
-		feegrantQueryCmd(),
-		govQueryCmd(),
-		slashingQueryCmd(),
-		*/
-
 	)
+
+	if false {
+		// TODO: enable these when commands are available
+		cmd.AddCommand(
+			feegrantQueryCmd(),
+			govQueryCmd(),
+			slashingQueryCmd(),
+		)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
Remove duplicate imports, and reference previously unused functions in
an unreachable block so that staticcheck does not consider them unused.

(Related to #109 but separate, as that PR changes an imported module and these are tamer changes.)