### PR TITLE
Miscellaneous cleanup in cmd package

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -33,6 +33,7 @@ func authAccountCmd() *cobra.Command {
 	}
 	return cmd
 }
+
 func authAccountsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "accounts",

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -66,7 +66,6 @@ func cmdChainsAdd() *cobra.Command {
 			}
 
 			for _, chain := range args {
-
 				found := false
 				for _, possibleChain := range allChains {
 					if chain == possibleChain {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -33,28 +32,18 @@ func createConfig(home string, debug bool) error {
 	}
 
 	// Then create the file...
-	f, err := os.Create(cfgPath)
-	if err != nil {
+	content := defaultConfig(path.Join(home, "keys"), debug)
+	if err := os.WriteFile(cfgPath, content, 0600); err != nil {
 		return err
 	}
-	defer f.Close()
 
-	// And write the default config to that location...
-	if _, err = f.Write(defaultConfig(path.Join(home, "keys"), debug)); err != nil {
-		return err
-	}
 	return nil
 }
 
 func overwriteConfig(cfg *Config) error {
 	home := viper.GetString("home")
 	cfgPath := path.Join(home, "config.yaml")
-	f, err := os.Create(cfgPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if _, err := f.Write(cfg.MustYAML()); err != nil {
+	if err := os.WriteFile(cfgPath, cfg.MustYAML(), 0600); err != nil {
 		return err
 	}
 
@@ -114,6 +103,7 @@ func defaultConfig(keyHome string, debug bool) []byte {
 }
 
 // initConfig reads in config file and ENV variables if set.
+// This is called as a persistent pre-run command of the root command.
 func initConfig(cmd *cobra.Command) error {
 	home, err := cmd.PersistentFlags().GetString(flags.FlagHome)
 	if err != nil {
@@ -137,21 +127,18 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetConfigFile(cfgPath)
 	err = viper.ReadInConfig()
 	if err != nil {
-		fmt.Println("Failed to read in config:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to read in config: %w", err)
 	}
 
 	// read the config file bytes
-	file, err := ioutil.ReadFile(viper.ConfigFileUsed())
+	file, err := os.ReadFile(viper.ConfigFileUsed())
 	if err != nil {
-		fmt.Println("Error reading file:", err)
-		os.Exit(1)
+		return fmt.Errorf("error reading config file: %w", err)
 	}
 
 	// unmarshall them into the struct
 	if err = yaml.Unmarshal(file, config); err != nil {
-		fmt.Println("Error unmarshalling config:", err)
-		os.Exit(1)
+		return fmt.Errorf("error unmarshalling config: %w", err)
 	}
 
 	// instantiate chain client
@@ -160,10 +147,9 @@ func initConfig(cmd *cobra.Command) error {
 	config.cl = make(map[string]*client.ChainClient)
 	for name, chain := range config.Chains {
 		chain.Modules = append([]module.AppModuleBasic{}, ModuleBasics...)
-		cl, err := client.NewChainClient(chain, home, os.Stdin, os.Stdout)
+		cl, err := client.NewChainClient(chain, home, cmd.InOrStdin(), cmd.OutOrStdout())
 		if err != nil {
-			fmt.Println("Error creating chain client:", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating chain client: %w", err)
 		}
 		config.cl[name] = cl
 	}
@@ -191,9 +177,8 @@ func initConfig(cmd *cobra.Command) error {
 	}
 
 	// validate configuration
-	if err = validateConfig(config); err != nil {
-		fmt.Println("Error parsing chain config:", err)
-		os.Exit(1)
+	if err := validateConfig(config); err != nil {
+		return fmt.Errorf("error validating config: %w", err)
 	}
 	return nil
 }

--- a/cmd/crosschain.go
+++ b/cmd/crosschain.go
@@ -105,7 +105,7 @@ func getEnabledChainbalancesCmd() *cobra.Command {
 					}
 				}
 				for denom, balance := range combinedBalanceMap {
-					fmt.Printf("%s: %s\n", denom, balance.String())
+					fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", denom, balance.String())
 				}
 			} else {
 				for _, chain := range enabledChains {
@@ -114,10 +114,10 @@ func getEnabledChainbalancesCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Println("==============================================================")
-					fmt.Printf("Chain: %s, Address: %s\n", chain, chainAddress)
+					fmt.Fprintln(cmd.OutOrStdout(), "==============================================================")
+					fmt.Fprintf(cmd.OutOrStdout(), "Chain: %s, Address: %s\n", chain, chainAddress)
 					for _, balance := range denomBalanceMap[chain] {
-						fmt.Printf("%s: %s\n", balance.Denom, balance.Amount.String())
+						fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", balance.Denom, balance.Amount.String())
 					}
 				}
 			}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -101,5 +101,4 @@ func ReadHeight(flagSet *pflag.FlagSet) (int64, error) {
 	} else {
 		return 0, nil
 	}
-
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -98,4 +100,18 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// writeJSON encodes the given object to the given writer.
+func writeJSON(w io.Writer, obj interface{}) error {
+	// Although simple, this is just subtle enough
+	// and used in enough places to justify its own function.
+
+	// Using an encoder is slightly preferable over json.Marshal
+	// as the encoder will write directly to the io.Writer
+	// instead of copying to a temporary buffer.
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(obj)
 }

--- a/cmd/tendermint.go
+++ b/cmd/tendermint.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -65,11 +64,10 @@ func abciInfoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(info, "", "  ")
-			if err != nil {
+
+			if err := writeJSON(cmd.OutOrStdout(), info); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -101,11 +99,9 @@ func abciQueryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(info, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), info); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -130,11 +126,9 @@ func blockCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -157,11 +151,9 @@ func blockByHashCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -185,11 +177,9 @@ func blockResultsCmd() *cobra.Command {
 				return err
 			}
 			// TODO: figure out how to fix the base64 output here
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -204,7 +194,7 @@ func blockSearchCmd() *cobra.Command {
 		// TODO: long explaination and example should include example queries
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("TODO")
+			fmt.Fprintln(cmd.OutOrStdout(), "TODO")
 			return nil
 		},
 	}
@@ -230,11 +220,9 @@ func consensusParamsCmd() *cobra.Command {
 				return err
 			}
 			// TODO: figure out how to fix the base64 output here
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -256,11 +244,9 @@ func consensusStateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -279,11 +265,9 @@ func dumpConsensusStateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -302,11 +286,9 @@ func healthCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -333,22 +315,21 @@ func netInfoCmd() *cobra.Command {
 				return err
 			}
 			if !peers {
-				bz, err := json.MarshalIndent(block, "", "  ")
-				if err != nil {
+				if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 					return err
 				}
-				fmt.Println(string(bz))
 				return nil
 			}
-			peersList := ""
+			peersList := make([]string, 0, len(block.Peers))
 			for _, peer := range block.Peers {
 				url, err := url.Parse(peer.NodeInfo.ListenAddr)
 				if err != nil {
+					fmt.Fprintf(cmd.OutOrStderr(), "error parsing addr %q: %v\n", peer.NodeInfo.ListenAddr, err)
 					continue
 				}
-				peersList += fmt.Sprintf("%s@%s:%s,", peer.NodeInfo.ID(), peer.RemoteIP, url.Port())
+				peersList = append(peersList, fmt.Sprintf("%s@%s:%s", peer.NodeInfo.ID(), peer.RemoteIP, url.Port()))
 			}
-			fmt.Println(strings.TrimSuffix(peersList, ","))
+			fmt.Fprintln(cmd.OutOrStdout(), strings.Join(peersList, ","))
 			return nil
 		},
 	}
@@ -376,11 +357,9 @@ func numUnconfirmedTxs() *cobra.Command {
 			// for _, txbz := range block.Txs {
 			// 	fmt.Printf("%X\n", tmtypes.Tx(txbz).Hash())
 			// }
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -399,11 +378,10 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bz, err := json.MarshalIndent(block, "", "  ")
-			if err != nil {
+
+			if err := writeJSON(cmd.OutOrStdout(), block); err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
 			return nil
 		},
 	}
@@ -430,7 +408,6 @@ func queryTxCmd() *cobra.Command {
 				return err
 			}
 			return cl.PrintObject(block)
-
 		},
 	}
 	return proveFlag(cmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
 	dbg "runtime/debug"
 
 	"github.com/spf13/cobra"
@@ -34,8 +32,9 @@ func versionCmd() *cobra.Command {
 				Tendermint: dependencyVersions["github.com/tendermint/tendermint"],
 			}
 
-			bz, _ := json.MarshalIndent(v, "", "  ")
-			fmt.Println(string(bz))
+			if err := writeJSON(cmd.OutOrStdout(), v); err != nil {
+				return err
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
- Avoid ioutil package
- Avoid directly calling os.Exit in helper function
- Use *cobra.Command object's stdout for printing (which will simplify
  future tests)
- Consistently write JSON values with indentation and without HTML
  escaping