### PR TITLE
Add initial pattern for tests in cmd package

### DIFF
--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -1,0 +1,51 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeysList_EmptyKeys(t *testing.T) {
+	sys := NewSystem(t)
+
+	res := sys.MustRun(t, "keys", "list")
+
+	// Before adding any keys, listing the keys gives a helpful message on stderr.
+	require.Empty(t, res.Stdout.String())
+	require.Contains(t, res.Stderr.String(), "no keys found")
+}
+
+func TestKeysAdd_List(t *testing.T) {
+	sys := NewSystem(t)
+
+	sys.MustRun(t, "keys", "add")
+
+	res := sys.MustRun(t, "keys", "list")
+	require.Contains(t, res.Stdout.String(), "key(default) -> cosmos1")
+	require.Empty(t, res.Stderr.String())
+}
+
+func TestKeysAdd_CustomName_List(t *testing.T) {
+	sys := NewSystem(t)
+
+	sys.MustRun(t, "keys", "add", "foo")
+
+	res := sys.MustRun(t, "keys", "list")
+	require.Contains(t, res.Stdout.String(), "key(foo) -> cosmos1")
+	require.Empty(t, res.Stderr.String())
+}
+
+func TestKeys_Restore(t *testing.T) {
+	sys := NewSystem(t)
+
+	in := strings.NewReader(ZeroMnemonic + "\n")
+	res := sys.MustRunWithInput(t, in, "keys", "restore", "mykey")
+	require.Equal(t, res.Stdout.String(), ZeroCosmosAddr+"\n")
+	// res.Stderr can be ignored here.
+
+	// After calling restore, the key can be retrieved through keys list.
+	res = sys.MustRun(t, "keys", "list")
+	require.Equal(t, res.Stdout.String(), "key(mykey) -> "+ZeroCosmosAddr+"\n")
+}

--- a/cmd/system_test.go
+++ b/cmd/system_test.go
@@ -1,0 +1,89 @@
+package cmd_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/strangelove-ventures/lens/cmd"
+)
+
+// System is a system under test.
+type System struct {
+	HomeDir string
+}
+
+// NewSystem creates a new system with a home dir associated with a temp dir belonging to t.
+//
+// The returned System does not store a reference to t;
+// some of its methods expect a *testing.T as an argument.
+// This allows creating one instance of System to be shared with subtests.
+func NewSystem(t *testing.T) *System {
+	t.Helper()
+
+	homeDir := t.TempDir()
+
+	return &System{
+		HomeDir: homeDir,
+	}
+}
+
+// RunResult is the stdout and stderr resulting from a call to (*System).Run,
+// and any error that was returned.
+type RunResult struct {
+	Stdout, Stderr bytes.Buffer
+
+	Err error
+}
+
+// Run calls s.RunWithInput with an empty stdin.
+func (s *System) Run(args ...string) RunResult {
+	return s.RunWithInput(bytes.NewReader(nil), args...)
+}
+
+// RunWithInput executes the root command with the given args,
+// providing in as the command's standard input,
+// and returns a RunResult that has its Stdout and Stderr populated.
+func (s *System) RunWithInput(in io.Reader, args ...string) RunResult {
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetIn(in)
+
+	var res RunResult
+	rootCmd.SetOutput(&res.Stdout)
+	rootCmd.SetErr(&res.Stderr)
+
+	// Prepend the system's home directory to any provided args.
+	args = append([]string{"--home", s.HomeDir}, args...)
+	rootCmd.SetArgs(args)
+
+	res.Err = rootCmd.Execute()
+	return res
+}
+
+// MustRun calls Run, but also calls t.Fatal if RunResult.Err is not nil.
+func (s *System) MustRun(t *testing.T, args ...string) RunResult {
+	t.Helper()
+
+	return s.MustRunWithInput(t, bytes.NewReader(nil), args...)
+}
+
+// MustRunWithInput calls RunWithInput, but also calls t.Fatal if RunResult.Err is not nil.
+func (s *System) MustRunWithInput(t *testing.T, in io.Reader, args ...string) RunResult {
+	t.Helper()
+
+	res := s.RunWithInput(in, args...)
+	if res.Err != nil {
+		t.Logf("Error executing %v: %v", args, res.Err)
+		t.Logf("Stdout: %q", res.Stdout.String())
+		t.Logf("Stderr: %q", res.Stderr.String())
+		t.FailNow()
+	}
+
+	return res
+}
+
+// A fixed mnemonic and its resulting cosmos address, helpful for tests that need a mnemonic.
+const (
+	ZeroMnemonic   = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+	ZeroCosmosAddr = "cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl"
+)

--- a/cmd/tendermint.go
+++ b/cmd/tendermint.go
@@ -324,7 +324,7 @@ func netInfoCmd() *cobra.Command {
 			for _, peer := range block.Peers {
 				url, err := url.Parse(peer.NodeInfo.ListenAddr)
 				if err != nil {
-					fmt.Fprintf(cmd.OutOrStderr(), "error parsing addr %q: %v\n", peer.NodeInfo.ListenAddr, err)
+					fmt.Fprintf(cmd.ErrOrStderr(), "error parsing addr %q: %v\n", peer.NodeInfo.ListenAddr, err)
 					continue
 				}
 				peersList = append(peersList, fmt.Sprintf("%s@%s:%s", peer.NodeInfo.ID(), peer.RemoteIP, url.Port()))


### PR DESCRIPTION
I've successfully used a pattern similar to this on previous projects.
This approach allows testing the command in-process and stubbing out
stdin, stdout, and stderr.

There are some filesystem interactions, so these tests ought to be run
with t.Parallel, but right now there is a data race around some global
state in commands.

(I have another branch ready to fix those data races, after this PR is merged.)