### PR TITLE
Avoid shared global state in cmd package

### DIFF
--- a/cmd/airdrop.go
+++ b/cmd/airdrop.go
@@ -13,14 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func airdropCmd() *cobra.Command {
+func airdropCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "airdrop [airdrop.json] [denom] [exclude] [key]?",
 		Short: "Airdrop coins to a specified address",
 		Long:  "The airdrop file consists of map[string]float64 where the key is the address on the target chain and the value is the amount of coins to be airdropped to that address/1e6 (i.e. atom instead of uatom). The airdrop command 1. checks the addresses in the file to ensure that they are valid for the given chain l",
 		Args:  cobra.RangeArgs(3, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			keyNameOrAddress := ""
 			if len(args) == 3 {
 				keyNameOrAddress = cl.Config.Key

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -3,16 +3,17 @@ package cmd
 import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func authAccountCmd() *cobra.Command {
+func authAccountCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "account [address]",
 		Aliases: []string{"acc"},
 		Short:   "query an account for its number and sequence or pass no arguement to query default account",
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			keyNameOrAddress := ""
 			if len(args) == 0 {
 				keyNameOrAddress = cl.Config.Key
@@ -34,14 +35,14 @@ func authAccountCmd() *cobra.Command {
 	return cmd
 }
 
-func authAccountsCmd() *cobra.Command {
+func authAccountsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "accounts",
 		Aliases: []string{"accs"},
 		Short:   "query all accounts on a given chain w/ pagination",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -54,17 +55,17 @@ func authAccountsCmd() *cobra.Command {
 			return cl.PrintObject(res)
 		},
 	}
-	return paginationFlags(cmd)
+	return paginationFlags(cmd, v)
 }
 
-func authParamsCmd() *cobra.Command {
+func authParamsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "parameters",
 		Aliases: []string{"param", "params", "p"},
 		Short:   "query the current auth parameters",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			res, err := authtypes.NewQueryClient(cl).Params(cmd.Context(), &authtypes.QueryParamsRequest{})
 			if err != nil {
 				return err

--- a/cmd/authz.go
+++ b/cmd/authz.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func authzGrantsCmd() *cobra.Command {
+func authzGrantsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grants [grantor] [grantee] [msg_type]?",
 		Aliases: []string{"grants"},
@@ -16,7 +17,7 @@ func authzGrantsCmd() *cobra.Command {
 			// and the grantee client. This will allow for use of a
 			// ledger as the grantor (i.e. cosmoshub-ledger in the config)
 			// and test keyringbacked for the grantee (i.e. cosmoshub)
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -52,14 +53,14 @@ func authzGrantsCmd() *cobra.Command {
 			return cl.PrintObject(res)
 		},
 	}
-	return paginationFlags(cmd)
+	return paginationFlags(cmd, v)
 }
 
 // TODO: rethink UX here. We should break this up into a number
 // of smaller commands. For example, we should have a grantSend,
 // grantStake, grantWithdraw, grantVote, grantValidator, etc...
 // authzGrantAuthorizationCmd returns the authz grant authorization command for this module
-func authzGrantAuthorizationCmd() *cobra.Command {
+func authzGrantAuthorizationCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grant [grantor] [grantee] [role]",
 		Aliases: []string{"grant"},
@@ -88,7 +89,7 @@ func authzGrantAuthorizationCmd() *cobra.Command {
 }
 
 // authzRevokeAuthorizationCmd returns the authz revoke authorization command for this module
-func authzRevokeAuthorizationCmd() *cobra.Command {
+func authzRevokeAuthorizationCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "revoke [grantee] [msg_type] [grantor]?",
 		Aliases: []string{"r"},
@@ -99,7 +100,7 @@ func authzRevokeAuthorizationCmd() *cobra.Command {
 			// and the grantee client. This will allow for use of a
 			// ledger as the grantor (i.e. cosmoshub-ledger in the config)
 			// and test keyringbacked for the grantee (i.e. cosmoshub)
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			var key string
 			if len(args) == 3 {
 				key = args[2]
@@ -127,7 +128,7 @@ func authzRevokeAuthorizationCmd() *cobra.Command {
 }
 
 // authzExecAuthorizationCmd returns the authz exec authorization command for this module
-func authzExecAuthorizationCmd() *cobra.Command {
+func authzExecAuthorizationCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "exec [msg_tx_json_file] [grantee]?",
 		Aliases: []string{"exec"},

--- a/cmd/bank.go
+++ b/cmd/bank.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -9,13 +10,13 @@ import (
 	query "github.com/strangelove-ventures/lens/client/query"
 )
 
-func bankSendCmd() *cobra.Command {
+func bankSendCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send [from] [to] [amount]",
 		Short: "send coins from one address to another",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			fromAddr, err := cl.AccountFromKeyOrAddress(args[0])
 			if err != nil {
 				return err
@@ -53,14 +54,14 @@ func bankSendCmd() *cobra.Command {
 
 // ========== Querier Functions ==========
 
-func bankBalanceCmd() *cobra.Command {
+func bankBalanceCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "balances [key-or-address]",
 		Aliases: []string{"bal", "b"},
 		Short:   "query the account balance for a key or address (if none is specified, the balance of the default account is returned)",
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -94,14 +95,14 @@ func bankBalanceCmd() *cobra.Command {
 	return cmd
 }
 
-func bankTotalSupplyCmd() *cobra.Command {
+func bankTotalSupplyCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "total-supply",
 		Aliases: []string{"totalsupply", "tot", "ts", "totsupplys"},
 		Short:   "query the total supply of coins in the chain",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -124,14 +125,14 @@ func bankTotalSupplyCmd() *cobra.Command {
 	return cmd
 }
 
-func bankDenomsMetadataCmd() *cobra.Command {
+func bankDenomsMetadataCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "denoms-metadata",
 		Aliases: []string{"denoms", "d"},
 		Short:   "query the denoms metadata",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -11,9 +11,10 @@ import (
 	"github.com/strangelove-ventures/lens/client/chain_registry"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func chainsCmd() *cobra.Command {
+func chainsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "chains",
 		Aliases: []string{"ch", "c"},
@@ -21,21 +22,21 @@ func chainsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		cmdChainsAdd(),
-		cmdChainsDelete(),
-		cmdChainsEdit(),
-		cmdChainsList(),
-		cmdChainsShow(),
-		cmdChainsSetDefault(),
-		cmdChainsRegistryList(),
-		cmdChainsShowDefault(),
+		cmdChainsAdd(v, lc),
+		cmdChainsDelete(v, lc),
+		cmdChainsEdit(v, lc),
+		cmdChainsList(lc),
+		cmdChainsShow(lc),
+		cmdChainsSetDefault(v, lc),
+		cmdChainsRegistryList(lc),
+		cmdChainsShowDefault(lc),
 		cmdChainsEditorDefault(),
 	)
 
 	return cmd
 }
 
-func cmdChainsRegistryList() *cobra.Command {
+func cmdChainsRegistryList(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "registry-list",
 		Args:    cobra.NoArgs,
@@ -46,13 +47,13 @@ func cmdChainsRegistryList() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return config.GetDefaultClient().PrintObject(chains)
+			return lc.config.GetDefaultClient().PrintObject(chains)
 		},
 	}
 	return cmd
 }
 
-func cmdChainsAdd() *cobra.Command {
+func cmdChainsAdd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add [[chain-name]]",
 		Args:    cobra.MinimumNArgs(1),
@@ -90,110 +91,110 @@ func cmdChainsAdd() *cobra.Command {
 					continue
 				}
 
-				config.Chains[chain] = chainConfig
+				lc.config.Chains[chain] = chainConfig
 			}
 
-			return overwriteConfig(config)
+			return overwriteConfig(v, &lc.config)
 		},
 	}
 	return cmd
 }
 
-func cmdChainsDelete() *cobra.Command {
+func cmdChainsDelete(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [[chain-name]]",
 		Aliases: []string{"d"},
 		Short:   "delete a chain from the configuration",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			originalChainCount := len(config.Chains)
+			originalChainCount := len(lc.config.Chains)
 			for _, arg := range args {
-				if config.DefaultChain == arg {
+				if lc.config.DefaultChain == arg {
 					log.Printf("ignoring delete request for %s, unable to delete default chain.", arg)
 					continue
 				}
-				delete(config.Chains, arg)
+				delete(lc.config.Chains, arg)
 			}
 
 			// If nothing was removed, there's no need to update the configuration file.
-			if len(config.Chains) == originalChainCount {
+			if len(lc.config.Chains) == originalChainCount {
 				return nil
 			}
 
-			return overwriteConfig(config)
+			return overwriteConfig(v, &lc.config)
 		},
 	}
 	return cmd
 }
 
-func cmdChainsEdit() *cobra.Command {
+func cmdChainsEdit(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "edit [chain-name] [key] [value]",
 		Aliases: []string{"e"},
 		Short:   "edit a chain configuration value",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, ok := config.Chains[args[0]]; !ok {
+			if _, ok := lc.config.Chains[args[0]]; !ok {
 				return fmt.Errorf("chain %s not found in configuration", args[0])
 			}
 			switch args[1] {
 			case "key":
-				config.Chains[args[0]].Key = args[2]
+				lc.config.Chains[args[0]].Key = args[2]
 			case "chain-id":
-				config.Chains[args[0]].ChainID = args[2]
+				lc.config.Chains[args[0]].ChainID = args[2]
 			case "rpc-addr":
-				config.Chains[args[0]].RPCAddr = args[2]
+				lc.config.Chains[args[0]].RPCAddr = args[2]
 			case "grpc-addr":
-				config.Chains[args[0]].GRPCAddr = args[2]
+				lc.config.Chains[args[0]].GRPCAddr = args[2]
 			case "account-prefix":
-				config.Chains[args[0]].AccountPrefix = args[2]
+				lc.config.Chains[args[0]].AccountPrefix = args[2]
 			case "gas-adjustment":
 				fl, err := strconv.ParseFloat(args[2], 64)
 				if err != nil {
 					return err
 				}
-				config.Chains[args[0]].GasAdjustment = fl
+				lc.config.Chains[args[0]].GasAdjustment = fl
 			case "gas-prices":
-				config.Chains[args[0]].GasPrices = args[2]
+				lc.config.Chains[args[0]].GasPrices = args[2]
 			case "debug":
 				b, err := strconv.ParseBool(args[2])
 				if err != nil {
 					return err
 				}
-				config.Chains[args[0]].Debug = b
+				lc.config.Chains[args[0]].Debug = b
 			case "timeout":
-				config.Chains[args[0]].Timeout = args[2]
+				lc.config.Chains[args[0]].Timeout = args[2]
 			default:
 				return fmt.Errorf("unknown key %s, try 'key', 'chain-id', 'rpc-addr', 'grpc-addr', 'account-prefix', 'gas-adjustment', 'gas-prices', 'debug', or 'timeout'", args[1])
 			}
-			return overwriteConfig(config)
+			return overwriteConfig(v, &lc.config)
 		},
 	}
 	return cmd
 }
 
-func cmdChainsList() *cobra.Command {
+func cmdChainsList(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"l"},
 		Short:   "List all chains in the configuration",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return config.GetDefaultClient().PrintObject(config.Chains)
+			return lc.config.GetDefaultClient().PrintObject(lc.config.Chains)
 		},
 	}
 	return cmd
 }
 
-func cmdChainsShow() *cobra.Command {
+func cmdChainsShow(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "show [chain-name]",
 		Aliases: []string{"s"},
 		Short:   "show an individual chain configuration",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if ch, ok := config.Chains[args[0]]; ok {
-				return config.GetDefaultClient().PrintObject(ch)
+			if ch, ok := lc.config.Chains[args[0]]; ok {
+				return lc.config.GetDefaultClient().PrintObject(ch)
 
 			}
 			return fmt.Errorf("chain %s not found", args[0])
@@ -202,16 +203,16 @@ func cmdChainsShow() *cobra.Command {
 	return cmd
 }
 
-func cmdChainsSetDefault() *cobra.Command {
+func cmdChainsSetDefault(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set-default [chain-name]",
 		Aliases: []string{"sd"},
 		Short:   "set the default chain",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, ok := config.Chains[args[0]]; ok {
-				config.DefaultChain = args[0]
-				return overwriteConfig(config)
+			if _, ok := lc.config.Chains[args[0]]; ok {
+				lc.config.DefaultChain = args[0]
+				return overwriteConfig(v, &lc.config)
 			}
 			return fmt.Errorf("chain %s not found", args[0])
 		},
@@ -219,14 +220,14 @@ func cmdChainsSetDefault() *cobra.Command {
 	return cmd
 }
 
-func cmdChainsShowDefault() *cobra.Command {
+func cmdChainsShowDefault(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "show-default",
 		Aliases: []string{"d", "default"},
 		Short:   "show the configured default chain",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return config.GetDefaultClient().PrintObject(config.DefaultChain)
+			return lc.config.GetDefaultClient().PrintObject(lc.config.DefaultChain)
 		},
 	}
 	return cmd

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,8 +40,8 @@ func createConfig(home string, debug bool) error {
 	return nil
 }
 
-func overwriteConfig(cfg *Config) error {
-	home := viper.GetString("home")
+func overwriteConfig(v *viper.Viper, cfg *Config) error {
+	home := v.GetString("home")
 	cfgPath := path.Join(home, "config.yaml")
 	if err := os.WriteFile(cfgPath, cfg.MustYAML(), 0600); err != nil {
 		return err
@@ -104,7 +104,7 @@ func defaultConfig(keyHome string, debug bool) []byte {
 
 // initConfig reads in config file and ENV variables if set.
 // This is called as a persistent pre-run command of the root command.
-func initConfig(cmd *cobra.Command) error {
+func initConfig(cmd *cobra.Command, v *viper.Viper, lc *lensConfig) error {
 	home, err := cmd.PersistentFlags().GetString(flags.FlagHome)
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func initConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	config = &Config{}
+	lc.config = Config{}
 	cfgPath := path.Join(home, "config.yaml")
 	_, err = os.Stat(cfgPath)
 	if err != nil {
@@ -124,34 +124,34 @@ func initConfig(cmd *cobra.Command) error {
 			return err
 		}
 	}
-	viper.SetConfigFile(cfgPath)
-	err = viper.ReadInConfig()
+	v.SetConfigFile(cfgPath)
+	err = v.ReadInConfig()
 	if err != nil {
 		return fmt.Errorf("failed to read in config: %w", err)
 	}
 
 	// read the config file bytes
-	file, err := os.ReadFile(viper.ConfigFileUsed())
+	file, err := os.ReadFile(v.ConfigFileUsed())
 	if err != nil {
 		return fmt.Errorf("error reading config file: %w", err)
 	}
 
 	// unmarshall them into the struct
-	if err = yaml.Unmarshal(file, config); err != nil {
+	if err = yaml.Unmarshal(file, &lc.config); err != nil {
 		return fmt.Errorf("error unmarshalling config: %w", err)
 	}
 
 	// instantiate chain client
 	// TODO: this is a bit of a hack, we should probably have a
 	// better way to inject modules into the client
-	config.cl = make(map[string]*client.ChainClient)
-	for name, chain := range config.Chains {
+	lc.config.cl = make(map[string]*client.ChainClient)
+	for name, chain := range lc.config.Chains {
 		chain.Modules = append([]module.AppModuleBasic{}, ModuleBasics...)
 		cl, err := client.NewChainClient(chain, home, cmd.InOrStdin(), cmd.OutOrStdout())
 		if err != nil {
 			return fmt.Errorf("error creating chain client: %w", err)
 		}
-		config.cl[name] = cl
+		lc.config.cl[name] = cl
 	}
 
 	// override chain if needed
@@ -161,7 +161,7 @@ func initConfig(cmd *cobra.Command) error {
 			return err
 		}
 
-		config.DefaultChain = defaultChain
+		lc.config.DefaultChain = defaultChain
 	}
 
 	if cmd.PersistentFlags().Changed("output") {
@@ -171,13 +171,13 @@ func initConfig(cmd *cobra.Command) error {
 		}
 
 		// Should output be a global configuration item?
-		for chain := range config.Chains {
-			config.Chains[chain].OutputFormat = output
+		for chain := range lc.config.Chains {
+			lc.config.Chains[chain].OutputFormat = output
 		}
 	}
 
 	// validate configuration
-	if err := validateConfig(config); err != nil {
+	if err := validateConfig(&lc.config); err != nil {
 		return fmt.Errorf("error validating config: %w", err)
 	}
 	return nil

--- a/cmd/crosschain.go
+++ b/cmd/crosschain.go
@@ -11,7 +11,7 @@ import (
 )
 
 // crosschainCmd represents the command to get balances across chains
-func crosschainCmd() *cobra.Command {
+func crosschainCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "crosschain",
 		Aliases: []string{"cc", "kriskross", "cchain", "coolchain"},
@@ -19,7 +19,7 @@ func crosschainCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		crosschainBankQueryCmd(),
+		crosschainBankQueryCmd(lc),
 	)
 
 	cmd.PersistentFlags().Bool("combined", false, "combine balances from all chains")
@@ -27,8 +27,8 @@ func crosschainCmd() *cobra.Command {
 	return cmd
 }
 
-// crosschainBankQueryCmd  returns the transaction commands for this module
-func crosschainBankQueryCmd() *cobra.Command {
+// crosschainBankQueryCmd returns the transaction commands for this module
+func crosschainBankQueryCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b"},
@@ -36,13 +36,13 @@ func crosschainBankQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		getEnabledChainbalancesCmd(),
+		getEnabledChainbalancesCmd(lc),
 	)
 
 	return cmd
 }
 
-func getEnabledChainbalancesCmd() *cobra.Command {
+func getEnabledChainbalancesCmd(lc *lensConfig) *cobra.Command {
 	return &cobra.Command{
 		Use:   "balances",
 		Args:  cobra.MinimumNArgs(1),
@@ -53,14 +53,14 @@ func getEnabledChainbalancesCmd() *cobra.Command {
 				return err
 			}
 			enabledChains := []string{}
-			for chain := range config.Chains {
+			for chain := range lc.config.Chains {
 				enabledChains = append(enabledChains, chain)
 			}
 			// alphabetically sort the chains - this is to make the output more readable/consistent
 			sort.StringSlice(enabledChains).Sort()
 
 			// copied from bank.go
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			var (
 				keyNameOrAddress = ""
 				address          sdk.AccAddress
@@ -82,7 +82,7 @@ func getEnabledChainbalancesCmd() *cobra.Command {
 			denomBalanceMap := make(map[string]sdk.Coins)
 			// end: copied from bank.go
 			for _, chain := range enabledChains {
-				cl := config.GetClient(chain)
+				cl := lc.config.GetClient(chain)
 				balance, err := cl.QueryBalanceWithDenomTraces(cmd.Context(), address, client.DefaultPageRequest())
 				if err != nil {
 					return err
@@ -109,7 +109,7 @@ func getEnabledChainbalancesCmd() *cobra.Command {
 				}
 			} else {
 				for _, chain := range enabledChains {
-					cl := config.GetClient(chain)
+					cl := lc.config.GetClient(chain)
 					chainAddress, err := cl.EncodeBech32AccAddr(address)
 					if err != nil {
 						return err

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -7,9 +7,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-var (
+const (
 	FlagCommission = "commission"
 	FlagAll        = "all"
 )
@@ -18,7 +19,7 @@ var (
 // if so then we should make the first arg manditory and further args be []sdk.ValAddr
 // and make the []sdk.ValAddr optional. This way we don't need any of the flags except
 // commission
-func distributionWithdrawRewardsCmd() *cobra.Command {
+func distributionWithdrawRewardsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "withdraw-rewards [validator-addr] [from]",
 		Short: "Withdraw rewards from a given delegation address, and optionally withdraw validator commission if the delegation address given is a validator operator",
@@ -33,7 +34,7 @@ $ lens tx withdraw-rewards --from mykey --all
 		),
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			key := ""
 			if len(args) == 1 {
 				key = cl.Config.Key
@@ -49,7 +50,6 @@ $ lens tx withdraw-rewards --from mykey --all
 			msgs := []sdk.Msg{}
 
 			if all, _ := cmd.Flags().GetBool(FlagAll); all {
-
 				validators, err := cl.QueryDelegatorValidators(cmd.Context(), delAddr)
 				if err != nil {
 					return err
@@ -90,12 +90,12 @@ $ lens tx withdraw-rewards --from mykey --all
 	return cmd
 }
 
-func distributionParamsCmd() *cobra.Command {
+func distributionParamsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "query things about a chain's distribution params",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 
 			params, err := cl.QueryDistributionParams(cmd.Context())
 			if err != nil {
@@ -109,12 +109,12 @@ func distributionParamsCmd() *cobra.Command {
 	return cmd
 }
 
-func distributionCommunityPoolCmd() *cobra.Command {
+func distributionCommunityPoolCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "community-pool",
 		Short: "query things about a chain's community pool",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 
 			pool, err := cl.QueryDistributionCommunityPool(cmd.Context())
 			if err != nil {
@@ -128,13 +128,13 @@ func distributionCommunityPoolCmd() *cobra.Command {
 	return cmd
 }
 
-func distributionCommissionCmd() *cobra.Command {
+func distributionCommissionCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commission [validator-address]",
 		Args:  cobra.ExactArgs(1),
 		Short: "query a specific validator's commission",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			address, err := cl.DecodeBech32ValAddr(args[0])
 			if err != nil {
 				return err
@@ -152,13 +152,13 @@ func distributionCommissionCmd() *cobra.Command {
 	return cmd
 }
 
-func distributionRewardsCmd() *cobra.Command {
+func distributionRewardsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rewards [key-or-delegator-address] [validator-address]",
 		Short: "query things about a delegator's rewards",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			delAddr, err := cl.AccountFromKeyOrAddress(args[0])
 			if err != nil {
 				return err
@@ -181,13 +181,13 @@ func distributionRewardsCmd() *cobra.Command {
 	return cmd
 }
 
-func distributionSlashesCmd() *cobra.Command {
+func distributionSlashesCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "slashes [validator-address] [start-height] [end-height]",
 		Short: "query things about a validator's slashes on a chain",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -218,16 +218,16 @@ func distributionSlashesCmd() *cobra.Command {
 		},
 	}
 
-	return paginationFlags(cmd)
+	return paginationFlags(cmd, v)
 }
 
-func distributionValidatorRewardsCmd() *cobra.Command {
+func distributionValidatorRewardsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validator-outstanding-rewards [address]",
 		Short: "query things about a validator's (and all their delegators) outstanding rewards on a chain",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 
 			address, err := cl.DecodeBech32ValAddr(args[0])
 			if err != nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,27 +9,27 @@ import (
 	"github.com/spf13/viper"
 )
 
-func peersFlag(cmd *cobra.Command) *cobra.Command {
+func peersFlag(cmd *cobra.Command, v *viper.Viper) *cobra.Command {
 	cmd.Flags().Bool("peers", false, "Comma-delimited list of peers to connect to for syncing")
-	viper.BindPFlag("peers", cmd.Flags().Lookup("peers"))
+	v.BindPFlag("peers", cmd.Flags().Lookup("peers"))
 	return cmd
 }
 
-func proveFlag(cmd *cobra.Command) *cobra.Command {
+func proveFlag(cmd *cobra.Command, v *viper.Viper) *cobra.Command {
 	cmd.Flags().Bool("prove", false, "return the proof as well as the result")
-	viper.BindPFlag("prove", cmd.Flags().Lookup("prove"))
+	v.BindPFlag("prove", cmd.Flags().Lookup("prove"))
 	return cmd
 }
 
-func limitFlag(cmd *cobra.Command) *cobra.Command {
+func limitFlag(cmd *cobra.Command, v *viper.Viper) *cobra.Command {
 	cmd.Flags().Int("limit", 100, "limit the number of things to fetch")
-	viper.BindPFlag("limit", cmd.Flags().Lookup("limit"))
+	v.BindPFlag("limit", cmd.Flags().Lookup("limit"))
 	return cmd
 }
 
-func skipConfirm(cmd *cobra.Command) *cobra.Command {
+func skipConfirm(cmd *cobra.Command, v *viper.Viper) *cobra.Command {
 	cmd.Flags().BoolP("skip", "y", false, "output using yaml")
-	viper.BindPFlag("skip", cmd.Flags().Lookup("skip"))
+	v.BindPFlag("skip", cmd.Flags().Lookup("skip"))
 	return cmd
 }
 
@@ -43,24 +43,24 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 }
 
 // AddPaginationFlagsToCmd adds common pagination flags to cmd
-func paginationFlags(cmd *cobra.Command) *cobra.Command {
+func paginationFlags(cmd *cobra.Command, v *viper.Viper) *cobra.Command {
 	cmd.Flags().Uint64("page", 1, "pagination page of objects to query for. This sets offset to a multiple of limit")
-	viper.BindPFlag("page", cmd.Flags().Lookup("page"))
+	v.BindPFlag("page", cmd.Flags().Lookup("page"))
 
 	cmd.Flags().String("page-key", "", "pagination page-key of objects to query for")
-	viper.BindPFlag("page-key", cmd.Flags().Lookup("page-key"))
+	v.BindPFlag("page-key", cmd.Flags().Lookup("page-key"))
 
 	cmd.Flags().Uint64("limit", 100, "pagination limit of objects to query for")
-	viper.BindPFlag("limit", cmd.Flags().Lookup("limit"))
+	v.BindPFlag("limit", cmd.Flags().Lookup("limit"))
 
 	cmd.Flags().Uint64("offset", 0, "pagination offset of objects to query for")
-	viper.BindPFlag("offset", cmd.Flags().Lookup("offset"))
+	v.BindPFlag("offset", cmd.Flags().Lookup("offset"))
 
 	cmd.Flags().Bool("count-total", true, "count total number of records in objects to query for")
-	viper.BindPFlag("count-total", cmd.Flags().Lookup("count-total"))
+	v.BindPFlag("count-total", cmd.Flags().Lookup("count-total"))
 
 	cmd.Flags().Bool("reverse", false, "results are sorted in descending order")
-	viper.BindPFlag("reverse", cmd.Flags().Lookup("reverse"))
+	v.BindPFlag("reverse", cmd.Flags().Lookup("reverse"))
 	return cmd
 }
 

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestKeysList_EmptyKeys(t *testing.T) {
+	t.Parallel()
+
 	sys := NewSystem(t)
 
 	res := sys.MustRun(t, "keys", "list")
@@ -18,6 +20,8 @@ func TestKeysList_EmptyKeys(t *testing.T) {
 }
 
 func TestKeysAdd_List(t *testing.T) {
+	t.Parallel()
+
 	sys := NewSystem(t)
 
 	sys.MustRun(t, "keys", "add")
@@ -28,6 +32,8 @@ func TestKeysAdd_List(t *testing.T) {
 }
 
 func TestKeysAdd_CustomName_List(t *testing.T) {
+	t.Parallel()
+
 	sys := NewSystem(t)
 
 	sys.MustRun(t, "keys", "add", "foo")
@@ -38,6 +44,8 @@ func TestKeysAdd_CustomName_List(t *testing.T) {
 }
 
 func TestKeys_Restore(t *testing.T) {
+	t.Parallel()
+
 	sys := NewSystem(t)
 
 	in := strings.NewReader(ZeroMnemonic + "\n")

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-// queryCmd represents the keys command
-func queryCmd() *cobra.Command {
+// queryCmd represents the query command tree.
+func queryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "query",
 		Aliases: []string{"q"},
@@ -13,11 +14,11 @@ func queryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authQueryCmd(),
-		authzQueryCmd(),
-		bankQueryCmd(),
-		distributionQueryCmd(),
-		stakingQueryCmd(),
+		authQueryCmd(v, lc),
+		authzQueryCmd(v, lc),
+		bankQueryCmd(lc),
+		distributionQueryCmd(v, lc),
+		stakingQueryCmd(lc),
 	)
 
 	if false {
@@ -33,7 +34,7 @@ func queryCmd() *cobra.Command {
 }
 
 // authQueryCmd returns the transaction commands for this module
-func authQueryCmd() *cobra.Command {
+func authQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "auth",
 		Aliases: []string{"a"},
@@ -41,16 +42,16 @@ func authQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authAccountCmd(),
-		authAccountsCmd(),
-		authParamsCmd(),
+		authAccountCmd(lc),
+		authAccountsCmd(v, lc),
+		authParamsCmd(lc),
 	)
 
 	return cmd
 }
 
 // authzQueryCmd returns the authz query commands for this module
-func authzQueryCmd() *cobra.Command {
+func authzQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "authz",
 		Aliases: []string{"authz"},
@@ -58,14 +59,14 @@ func authzQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authzGrantsCmd(),
+		authzGrantsCmd(v, lc),
 	)
 
 	return cmd
 }
 
 // bankQueryCmd  returns the transaction commands for this module
-func bankQueryCmd() *cobra.Command {
+func bankQueryCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b"},
@@ -73,16 +74,16 @@ func bankQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		bankBalanceCmd(),
-		bankTotalSupplyCmd(),
-		bankDenomsMetadataCmd(),
+		bankBalanceCmd(lc),
+		bankTotalSupplyCmd(lc),
+		bankDenomsMetadataCmd(lc),
 	)
 
 	return cmd
 }
 
 // distributionQueryCmd returns the distribution query commands for this module
-func distributionQueryCmd() *cobra.Command {
+func distributionQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "distribution",
 		Aliases: []string{"dist", "distr", "d"},
@@ -90,12 +91,12 @@ func distributionQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		distributionParamsCmd(),
-		distributionValidatorRewardsCmd(),
-		distributionCommissionCmd(),
-		distributionCommunityPoolCmd(),
-		distributionRewardsCmd(),
-		distributionSlashesCmd(),
+		distributionParamsCmd(lc),
+		distributionValidatorRewardsCmd(lc),
+		distributionCommissionCmd(lc),
+		distributionCommunityPoolCmd(lc),
+		distributionRewardsCmd(lc),
+		distributionSlashesCmd(v, lc),
 	)
 
 	return cmd
@@ -159,7 +160,7 @@ func slashingQueryCmd() *cobra.Command {
 }
 
 // stakingQueryCmd returns the staking query commands for this module
-func stakingQueryCmd() *cobra.Command {
+func stakingQueryCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "staking",
 		Aliases: []string{"stake", "s"},
@@ -167,8 +168,8 @@ func stakingQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		stakingDelegationCmd(),
-		stakingDelegationsCmd(),
+		stakingDelegationCmd(lc),
+		stakingDelegationsCmd(lc),
 		// stakingUnbondingDelegationCmd(),
 		// stakingUnbondingDelegationsCmd(),
 		// stakingRedelegationCmd(),

--- a/cmd/staking.go
+++ b/cmd/staking.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/strangelove-ventures/lens/client/query"
 	"strings"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
@@ -9,9 +8,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/spf13/cobra"
+	"github.com/strangelove-ventures/lens/client/query"
 )
 
-func stakingDelegateCmd() *cobra.Command {
+func stakingDelegateCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegate [validator-addr] [amount] ",
 		Args:  cobra.ExactArgs(2),
@@ -23,13 +23,12 @@ $ lens tx staking delegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0 
 		),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			var (
 				delAddr sdk.AccAddress
 				err     error
 			)
 
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 
 			if args[2] != cl.Config.Key {
 				cl.Config.Key = args[2]
@@ -77,7 +76,7 @@ $ lens tx staking delegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0 
 	return cmd
 }
 
-func stakingRedelegateCmd() *cobra.Command {
+func stakingRedelegateCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redelegate [from] [src-validator-addr] [dst-validator-addr] [amount]",
 		Short: "redelegate tokens from one validator to another",
@@ -89,7 +88,7 @@ $ lens tx staking redelegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj
 `,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			key, _ := cmd.Flags().GetString(FlagFrom)
 			delAddr, err := cl.AccountFromKeyOrAddress(key)
 			if err != nil {
@@ -127,7 +126,7 @@ $ lens tx staking redelegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj
 	return cmd
 }
 
-func stakingDelegationsCmd() *cobra.Command {
+func stakingDelegationsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegations [delegator-addr]",
 		Short: "query all delegations for a delegator address",
@@ -138,7 +137,7 @@ $ lens query staking delegations cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 `),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			pr, err := sdkclient.ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -161,7 +160,7 @@ $ lens query staking delegations cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 	return cmd
 }
 
-func stakingDelegationCmd() *cobra.Command {
+func stakingDelegationCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegation [delegator-addr] [validator-addr]",
 		Short: "query a delegation based on a delegator address and validator address",
@@ -172,7 +171,7 @@ $ lens query staking delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p co
 `),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			cq := query.Query{Client: cl, Options: query.DefaultOptions()}
 			delegator := args[0]
 			validator := args[1]

--- a/cmd/tendermint.go
+++ b/cmd/tendermint.go
@@ -23,43 +23,44 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 )
 
 // tendermintCmd represents the tendermint command
-func tendermintCmd() *cobra.Command {
+func tendermintCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "tendermint",
 		Aliases: []string{"tm"},
 		Short:   "all tendermint query commands",
 	}
 	cmd.AddCommand(
-		abciInfoCmd(),
-		abciQueryCmd(),
-		blockCmd(),
-		blockByHashCmd(),
-		blockResultsCmd(),
+		abciInfoCmd(lc),
+		abciQueryCmd(lc),
+		blockCmd(lc),
+		blockByHashCmd(lc),
+		blockResultsCmd(lc),
 		blockSearchCmd(),
-		consensusParamsCmd(),
-		consensusStateCmd(),
-		dumpConsensusStateCmd(),
-		healthCmd(),
-		netInfoCmd(),
-		numUnconfirmedTxs(),
-		statusCmd(),
-		queryTxCmd(),
+		consensusParamsCmd(lc),
+		consensusStateCmd(lc),
+		dumpConsensusStateCmd(lc),
+		healthCmd(lc),
+		netInfoCmd(v, lc),
+		numUnconfirmedTxs(v, lc),
+		statusCmd(lc),
+		queryTxCmd(v, lc),
 	)
 	return cmd
 }
 
-func abciInfoCmd() *cobra.Command {
+func abciInfoCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "abci-info",
 		Aliases: []string{"abcii"},
 		Short:   "queries for block height, app name and app hash",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			info, err := cl.RPCClient.ABCIInfo(cmd.Context())
 			if err != nil {
 				return err
@@ -74,14 +75,14 @@ func abciInfoCmd() *cobra.Command {
 	return cmd
 }
 
-func abciQueryCmd() *cobra.Command {
+func abciQueryCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "abci-query [path] [data] [height]",
 		Aliases: []string{"qabci"},
 		Short:   "query the abci interface for tendermint directly",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			path := args[0]
 			data := []byte(args[1])
 			height, err := strconv.ParseInt(args[2], 10, 64)
@@ -109,7 +110,7 @@ func abciQueryCmd() *cobra.Command {
 	return cmd
 }
 
-func blockCmd() *cobra.Command {
+func blockCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: make this use a height flag and make height arg optional
 		Use:     "block [height]",
@@ -117,7 +118,7 @@ func blockCmd() *cobra.Command {
 		Short:   "query tendermint data for a block at given height",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			height, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return err
@@ -135,14 +136,14 @@ func blockCmd() *cobra.Command {
 	return cmd
 }
 
-func blockByHashCmd() *cobra.Command {
+func blockByHashCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "block-by-hash [hash]",
 		Aliases: []string{"blhash", "blh"},
 		Short:   "query tendermint for a given block by hash",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			h, err := hex.DecodeString(args[0])
 			if err != nil {
 				return err
@@ -160,14 +161,14 @@ func blockByHashCmd() *cobra.Command {
 	return cmd
 }
 
-func blockResultsCmd() *cobra.Command {
+func blockResultsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "block-results [height]",
 		Aliases: []string{"blres"},
 		Short:   "query tendermint tx results for a given block by height",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			height, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return err
@@ -202,7 +203,7 @@ func blockSearchCmd() *cobra.Command {
 	return cmd
 }
 
-func consensusParamsCmd() *cobra.Command {
+func consensusParamsCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: make this use a height flag and make height arg optional
 		Use:     "consensus-params [height]",
@@ -210,7 +211,7 @@ func consensusParamsCmd() *cobra.Command {
 		Short:   "query tendermint consensus params at a given height",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			height, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return err
@@ -229,7 +230,7 @@ func consensusParamsCmd() *cobra.Command {
 	return cmd
 }
 
-func consensusStateCmd() *cobra.Command {
+func consensusStateCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: add special flag to this for network startup
 		// that runs query on timer and shows a progress bar
@@ -239,7 +240,7 @@ func consensusStateCmd() *cobra.Command {
 		Short:   "query current tendermint consensus state",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			block, err := cl.RPCClient.ConsensusState(cmd.Context())
 			if err != nil {
 				return err
@@ -253,14 +254,14 @@ func consensusStateCmd() *cobra.Command {
 	return cmd
 }
 
-func dumpConsensusStateCmd() *cobra.Command {
+func dumpConsensusStateCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dump-consensus-state",
 		Aliases: []string{"dump-cs", "csdump", "cs-dump", "dumpcs"},
 		Short:   "query detailed version of current tendermint consensus state",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			block, err := cl.RPCClient.DumpConsensusState(cmd.Context())
 			if err != nil {
 				return err
@@ -274,14 +275,14 @@ func dumpConsensusStateCmd() *cobra.Command {
 	return cmd
 }
 
-func healthCmd() *cobra.Command {
+func healthCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "health",
 		Aliases: []string{"h", "ok"},
 		Short:   "query to see if node server is online",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			block, err := cl.RPCClient.Health(cmd.Context())
 			if err != nil {
 				return err
@@ -295,7 +296,7 @@ func healthCmd() *cobra.Command {
 	return cmd
 }
 
-func netInfoCmd() *cobra.Command {
+func netInfoCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	// TODO: add flag for pulling out comma seperated list of peers
 	// and also filter out private IPs and other ill formed peers
 	// _{*extraCredit*}_
@@ -305,7 +306,7 @@ func netInfoCmd() *cobra.Command {
 		Short:   "query for p2p network connection information",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			peers, err := cmd.Flags().GetBool("peers")
 			if err != nil {
 				return err
@@ -333,10 +334,10 @@ func netInfoCmd() *cobra.Command {
 			return nil
 		},
 	}
-	return peersFlag(cmd)
+	return peersFlag(cmd, v)
 }
 
-func numUnconfirmedTxs() *cobra.Command {
+func numUnconfirmedTxs(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	// TODO: add example for parsing these txs
 	// _{*extraCredit*}_
 	cmd := &cobra.Command{
@@ -345,7 +346,7 @@ func numUnconfirmedTxs() *cobra.Command {
 		Short:   "query for number of unconfirmed txs",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			limit, err := cmd.Flags().GetInt("limit")
 			if err != nil {
 				return err
@@ -363,17 +364,17 @@ func numUnconfirmedTxs() *cobra.Command {
 			return nil
 		},
 	}
-	return limitFlag(cmd)
+	return limitFlag(cmd, v)
 }
 
-func statusCmd() *cobra.Command {
+func statusCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status",
 		Aliases: []string{"stat", "s"},
 		Short:   "query status of the node",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			block, err := cl.RPCClient.Status(cmd.Context())
 			if err != nil {
 				return err
@@ -388,13 +389,13 @@ func statusCmd() *cobra.Command {
 	return cmd
 }
 
-func queryTxCmd() *cobra.Command {
+func queryTxCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx [hash]",
 		Short: "query for a transaction by hash",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := config.GetDefaultClient()
+			cl := lc.config.GetDefaultClient()
 			prove, err := cmd.Flags().GetBool("prove")
 			if err != nil {
 				return err
@@ -410,5 +411,5 @@ func queryTxCmd() *cobra.Command {
 			return cl.PrintObject(block)
 		},
 	}
-	return proveFlag(cmd)
+	return proveFlag(cmd, v)
 }

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -5,7 +5,7 @@ import (
 )
 
 // TxCommand registers a new tx command.
-func txCmd() *cobra.Command {
+func txCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx",
 		Short: "broadcast transactions to a chain",
@@ -13,12 +13,12 @@ func txCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		authTxCmd(),
-		authzTxCmd(),
-		bankTxCmd(),
-		distributionTxCmd(),
+		authzTxCmd(lc),
+		bankTxCmd(lc),
+		distributionTxCmd(lc),
 		feegrantTxCmd(),
 		govTxCmd(),
-		stakingTxCmd(),
+		stakingTxCmd(lc),
 		slashingTxCmd(),
 	)
 
@@ -40,7 +40,7 @@ func authTxCmd() *cobra.Command {
 }
 
 // authzTxCmd returns the authz tx commands for this module
-func authzTxCmd() *cobra.Command {
+func authzTxCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "authz",
 		Aliases: []string{"az"},
@@ -48,29 +48,29 @@ func authzTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authzGrantAuthorizationCmd(),
-		authzRevokeAuthorizationCmd(),
-		authzExecAuthorizationCmd(),
+		authzGrantAuthorizationCmd(lc),
+		authzRevokeAuthorizationCmd(lc),
+		authzExecAuthorizationCmd(lc),
 	)
 
 	return cmd
 }
 
 // bankTxCmd returns the bank tx commands for this module
-func bankTxCmd() *cobra.Command {
+func bankTxCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b", "bnk"},
 		Short:   "bank transaction commands",
 	}
 
-	cmd.AddCommand(bankSendCmd())
+	cmd.AddCommand(bankSendCmd(lc))
 
 	return cmd
 }
 
 // distributionTxCmd returns the distribution tx commands for this module
-func distributionTxCmd() *cobra.Command {
+func distributionTxCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "distribution",
 		Aliases: []string{"dist", "distr", "d"},
@@ -78,7 +78,7 @@ func distributionTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		distributionWithdrawRewardsCmd(),
+		distributionWithdrawRewardsCmd(lc),
 		// distributionSetWithdrawAddressCmd(),
 		// distributionFundCommunityPoolCmd(),
 	)
@@ -103,7 +103,7 @@ func feegrantTxCmd() *cobra.Command {
 }
 
 // stakingTxCmd returns the staking tx commands for this module
-func stakingTxCmd() *cobra.Command {
+func stakingTxCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "staking",
 		Aliases: []string{"stake", "stk"},
@@ -111,8 +111,8 @@ func stakingTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		stakingDelegateCmd(),
-		stakingRedelegateCmd(),
+		stakingDelegateCmd(lc),
+		stakingRedelegateCmd(lc),
 		// stakingCreateValidatorCmd(),
 		// stakingEditValidatorCmd(),
 		// stakingUnbondCmd(),


### PR DESCRIPTION
This builds on #112 to make those tests use t.Parallel, and it
eliminates data races by passing through config instances and a single
viper instance, instead of relying on global values.