### PR TITLE
Refactor query, additional modules and methods

### DIFF
--- a/client/query/bank.go
+++ b/client/query/bank.go
@@ -1,12 +1,7 @@
 package query
 
 import (
-	"context"
-	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"google.golang.org/grpc/metadata"
-	"strconv"
-	"time"
 )
 
 // BalanceWithAddressRPC returns the balance of all coins for a single account.
@@ -14,10 +9,7 @@ func BalanceWithAddressRPC(q *Query, address string) (*bankTypes.QueryAllBalance
 	var req *bankTypes.QueryAllBalancesRequest
 	req = &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: q.Options.Pagination}
 	queryClient := bankTypes.NewQueryClient(q.Client)
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.AllBalances(ctx, req)
 	if err != nil {
@@ -31,10 +23,7 @@ func BalanceWithAddressRPC(q *Query, address string) (*bankTypes.QueryAllBalance
 func TotalSupplyRPC(q *Query) (*bankTypes.QueryTotalSupplyResponse, error) {
 	req := &bankTypes.QueryTotalSupplyRequest{Pagination: q.Options.Pagination}
 	queryClient := bankTypes.NewQueryClient(q.Client)
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.TotalSupply(ctx, req)
 	if err != nil {
@@ -47,10 +36,7 @@ func TotalSupplyRPC(q *Query) (*bankTypes.QueryTotalSupplyResponse, error) {
 func DenomsMetadataRPC(q *Query) (*bankTypes.QueryDenomsMetadataResponse, error) {
 	req := &bankTypes.QueryDenomsMetadataRequest{Pagination: q.Options.Pagination}
 	queryClient := bankTypes.NewQueryClient(q.Client)
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.DenomsMetadata(ctx, req)
 	if err != nil {

--- a/client/query/distribution.go
+++ b/client/query/distribution.go
@@ -1,12 +1,7 @@
 package query
 
 import (
-	"context"
-	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	"google.golang.org/grpc/metadata"
-	"strconv"
-	"time"
 )
 
 // DelegatorValidatorsRPC returns the validators of a delegator
@@ -14,15 +9,11 @@ func DelegatorValidatorsRPC(q *Query, address string) (*distTypes.QueryDelegator
 	var req *distTypes.QueryDelegatorValidatorsRequest
 	req = &distTypes.QueryDelegatorValidatorsRequest{DelegatorAddress: address}
 	queryClient := distTypes.NewQueryClient(q.Client)
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.DelegatorValidators(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-
 	return res, nil
 }

--- a/client/query/distribution.go
+++ b/client/query/distribution.go
@@ -1,0 +1,28 @@
+package query
+
+import (
+	"context"
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"google.golang.org/grpc/metadata"
+	"strconv"
+	"time"
+)
+
+// DelegatorValidatorsRPC returns the validators of a delegator
+func DelegatorValidatorsRPC(q *Query, address string) (*distTypes.QueryDelegatorValidatorsResponse, error) {
+	var req *distTypes.QueryDelegatorValidatorsRequest
+	req = &distTypes.QueryDelegatorValidatorsRequest{DelegatorAddress: address}
+	queryClient := distTypes.NewQueryClient(q.Client)
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	strHeight := strconv.Itoa(int(q.Options.Height))
+	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	defer cancel()
+	res, err := queryClient.DelegatorValidators(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/client/query/querier.go
+++ b/client/query/querier.go
@@ -5,6 +5,7 @@ import (
 	distributionTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/strangelove-ventures/lens/client"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
 type Query struct {
@@ -46,4 +47,11 @@ func (q *Query) Delegations(delegator string) (*stakingTypes.QueryDelegatorDeleg
 func (q *Query) DelegatorValidators(delegator string) (*distributionTypes.QueryDelegatorValidatorsResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return DelegatorValidatorsRPC(q, delegator)
+}
+
+// Tendermint queries
+
+func (q *Query) Block() (*coretypes.ResultBlock, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return BlockRPC(q)
 }

--- a/client/query/querier.go
+++ b/client/query/querier.go
@@ -47,6 +47,12 @@ func (q *Query) Delegations(delegator string) (*stakingTypes.QueryDelegatorDeleg
 	return DelegationsRPC(q, delegator)
 }
 
+// ValidatorDelegations returns all the delegations for a validator
+func (q *Query) ValidatorDelegations(validator string) (*stakingTypes.QueryValidatorDelegationsResponse, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return ValidatorDelegationssRPC(q, validator)
+}
+
 // Distribution queries
 
 // DelegatorValidators returns the validators of a delegator

--- a/client/query/querier.go
+++ b/client/query/querier.go
@@ -2,7 +2,8 @@ package query
 
 import (
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/cosmos/cosmos-sdk/x/staking/types"
+	distributionTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/strangelove-ventures/lens/client"
 )
 
@@ -10,6 +11,8 @@ type Query struct {
 	Client  *client.ChainClient
 	Options *QueryOptions
 }
+
+// Bank queries
 
 func (q *Query) Balances(address string) (*bankTypes.QueryAllBalancesResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
@@ -26,12 +29,21 @@ func (q *Query) DenomsMetadata() (*bankTypes.QueryDenomsMetadataResponse, error)
 	return DenomsMetadataRPC(q)
 }
 
-func (q *Query) Delegation(delegator, validator string) (*types.DelegationResponse, error) {
+// Staking queries
+
+func (q *Query) Delegation(delegator, validator string) (*stakingTypes.DelegationResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
-	return Delegation(q, delegator, validator)
+	return DelegationRPC(q, delegator, validator)
 }
 
-func (q *Query) Delegations(delegator string) (*types.QueryDelegatorDelegationsResponse, error) {
+func (q *Query) Delegations(delegator string) (*stakingTypes.QueryDelegatorDelegationsResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
-	return Delegations(q, delegator)
+	return DelegationsRPC(q, delegator)
+}
+
+// Distribution queries
+
+func (q *Query) DelegatorValidators(delegator string) (*distributionTypes.QueryDelegatorValidatorsResponse, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return DelegatorValidatorsRPC(q, delegator)
 }

--- a/client/query/querier.go
+++ b/client/query/querier.go
@@ -15,16 +15,19 @@ type Query struct {
 
 // Bank queries
 
+// Balances returns the balance of all coins for a single account.
 func (q *Query) Balances(address string) (*bankTypes.QueryAllBalancesResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return BalanceWithAddressRPC(q, address)
 }
 
+// TotalSupply returns the supply of all coins
 func (q *Query) TotalSupply() (*bankTypes.QueryTotalSupplyResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return TotalSupplyRPC(q)
 }
 
+// DenomsMetadata returns the metadata for all denoms
 func (q *Query) DenomsMetadata() (*bankTypes.QueryDenomsMetadataResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return DenomsMetadataRPC(q)
@@ -32,11 +35,13 @@ func (q *Query) DenomsMetadata() (*bankTypes.QueryDenomsMetadataResponse, error)
 
 // Staking queries
 
+// Delegation returns the delegations to a particular validator
 func (q *Query) Delegation(delegator, validator string) (*stakingTypes.DelegationResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return DelegationRPC(q, delegator, validator)
 }
 
+// Delegations returns all the delegations
 func (q *Query) Delegations(delegator string) (*stakingTypes.QueryDelegatorDelegationsResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return DelegationsRPC(q, delegator)
@@ -44,6 +49,7 @@ func (q *Query) Delegations(delegator string) (*stakingTypes.QueryDelegatorDeleg
 
 // Distribution queries
 
+// DelegatorValidators returns the validators of a delegator
 func (q *Query) DelegatorValidators(delegator string) (*distributionTypes.QueryDelegatorValidatorsResponse, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return DelegatorValidatorsRPC(q, delegator)
@@ -51,7 +57,38 @@ func (q *Query) DelegatorValidators(delegator string) (*distributionTypes.QueryD
 
 // Tendermint queries
 
+// Block returns information about a block
 func (q *Query) Block() (*coretypes.ResultBlock, error) {
 	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
 	return BlockRPC(q)
+}
+
+// BlockByHash returns information about a block by hash
+func (q *Query) BlockByHash(hash string) (*coretypes.ResultBlock, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return BlockByHashRPC(q, hash)
+}
+
+// BlockResults returns information about a block by hash
+func (q *Query) BlockResults() (*coretypes.ResultBlockResults, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return BlockResultsRPC(q)
+}
+
+// Status returns information about a node status
+func (q *Query) Status() (*coretypes.ResultStatus, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return StatusRPC(q)
+}
+
+// ABCIInfo returns general information about the ABCI application
+func (q *Query) ABCIInfo() (*coretypes.ResultABCIInfo, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return ABCIInfoRPC(q)
+}
+
+// ABCIQuery returns data from a particular path in the ABCI application
+func (q *Query) ABCIQuery(path string, data string, prove bool) (*coretypes.ResultABCIQuery, error) {
+	/// TODO: In the future have some logic to route the query to the appropriate client (gRPC or RPC)
+	return ABCIQueryRPC(q, path, data, prove)
 }

--- a/client/query/query_options.go
+++ b/client/query/query_options.go
@@ -1,6 +1,13 @@
 package query
 
-import "github.com/cosmos/cosmos-sdk/types/query"
+import (
+	"context"
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"google.golang.org/grpc/metadata"
+	"strconv"
+	"time"
+)
 
 type QueryOptions struct {
 	Pagination *query.PageRequest
@@ -17,4 +24,13 @@ func DefaultOptions() *QueryOptions {
 		},
 		Height: 0,
 	}
+}
+
+// GetQueryContext returns a context that includes the height and uses the timeout from the config
+func (q *Query) GetQueryContext() (context.Context, context.CancelFunc) {
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	strHeight := strconv.Itoa(int(q.Options.Height))
+	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	return ctx, cancel
 }

--- a/client/query/staking.go
+++ b/client/query/staking.go
@@ -48,3 +48,28 @@ func DelegationsRPC(q *Query, delegator string) (*stakingTypes.QueryDelegatorDel
 
 	return res, nil
 }
+
+// ValidatorDelegationssRPC returns all the delegations for a validator
+func ValidatorDelegationssRPC(q *Query, validator string) (*stakingTypes.QueryValidatorDelegationsResponse, error) {
+	// ensure the validator parameter is a valid validator address
+	_, err := q.Client.DecodeBech32ValAddr(validator)
+	if err != nil {
+		return nil, err
+	}
+	queryClient := stakingTypes.NewQueryClient(q.Client)
+	params := &stakingTypes.QueryValidatorDelegationsRequest{
+		ValidatorAddr: validator,
+		Pagination:    q.Options.Pagination,
+	}
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	strHeight := strconv.Itoa(int(q.Options.Height))
+	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	defer cancel()
+	res, err := queryClient.ValidatorDelegations(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/client/query/staking.go
+++ b/client/query/staking.go
@@ -1,12 +1,7 @@
 package query
 
 import (
-	"context"
-	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"google.golang.org/grpc/metadata"
-	"strconv"
-	"time"
 )
 
 // DelegationRPC returns the delegations to a particular validator
@@ -16,12 +11,9 @@ func DelegationRPC(q *Query, delegator, validator string) (*stakingTypes.Delegat
 		DelegatorAddr: delegator,
 		ValidatorAddr: validator,
 	}
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
-	res, err := queryClient.Delegation(context.Background(), params)
+	res, err := queryClient.Delegation(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -36,10 +28,7 @@ func DelegationsRPC(q *Query, delegator string) (*stakingTypes.QueryDelegatorDel
 		DelegatorAddr: delegator,
 		Pagination:    q.Options.Pagination,
 	}
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.DelegatorDelegations(ctx, params)
 	if err != nil {
@@ -61,10 +50,7 @@ func ValidatorDelegationssRPC(q *Query, validator string) (*stakingTypes.QueryVa
 		ValidatorAddr: validator,
 		Pagination:    q.Options.Pagination,
 	}
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	strHeight := strconv.Itoa(int(q.Options.Height))
-	ctx = metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strHeight)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := queryClient.ValidatorDelegations(ctx, params)
 	if err != nil {

--- a/client/query/staking.go
+++ b/client/query/staking.go
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-// Delegation returns the delegations to a particular validator
-func Delegation(q *Query, delegator, validator string) (*stakingTypes.DelegationResponse, error) {
+// DelegationRPC returns the delegations to a particular validator
+func DelegationRPC(q *Query, delegator, validator string) (*stakingTypes.DelegationResponse, error) {
 	queryClient := stakingTypes.NewQueryClient(q.Client)
 	params := &stakingTypes.QueryDelegationRequest{
 		DelegatorAddr: delegator,
@@ -29,8 +29,8 @@ func Delegation(q *Query, delegator, validator string) (*stakingTypes.Delegation
 	return res.DelegationResponse, nil
 }
 
-// Delegations returns all the delegations
-func Delegations(q *Query, delegator string) (*stakingTypes.QueryDelegatorDelegationsResponse, error) {
+// DelegationsRPC returns all the delegations
+func DelegationsRPC(q *Query, delegator string) (*stakingTypes.QueryDelegatorDelegationsResponse, error) {
 	queryClient := stakingTypes.NewQueryClient(q.Client)
 	params := &stakingTypes.QueryDelegatorDelegationsRequest{
 		DelegatorAddr: delegator,

--- a/client/query/tendermint.go
+++ b/client/query/tendermint.go
@@ -1,18 +1,15 @@
 package query
 
 import (
-	"context"
 	"encoding/hex"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
-	"time"
 )
 
 // BlockRPC returns information about a block
 func BlockRPC(q *Query) (*coretypes.ResultBlock, error) {
 	var height int64
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	// If height is not specified, default value is 0, query the latest available block then
 	if q.Options.Height == 0 {
@@ -34,8 +31,7 @@ func BlockRPC(q *Query) (*coretypes.ResultBlock, error) {
 
 // BlockByHashRPC returns information about a block by hash
 func BlockByHashRPC(q *Query, hash string) (*coretypes.ResultBlock, error) {
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	h, err := hex.DecodeString(hash)
 	if err != nil {
@@ -51,8 +47,7 @@ func BlockByHashRPC(q *Query, hash string) (*coretypes.ResultBlock, error) {
 // BlockResultsRPC returns information about a block by hash
 func BlockResultsRPC(q *Query) (*coretypes.ResultBlockResults, error) {
 	var height int64
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	// If height is not specified, default value is 0, query the latest available block then
 	if q.Options.Height == 0 {
@@ -74,8 +69,7 @@ func BlockResultsRPC(q *Query) (*coretypes.ResultBlockResults, error) {
 
 // StatusRPC returns information about a node status
 func StatusRPC(q *Query) (*coretypes.ResultStatus, error) {
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := q.Client.RPCClient.Status(ctx)
 	if err != nil {
@@ -87,8 +81,7 @@ func StatusRPC(q *Query) (*coretypes.ResultStatus, error) {
 
 // ABCIInfoRPC returns information about the ABCI application
 func ABCIInfoRPC(q *Query) (*coretypes.ResultABCIInfo, error) {
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	res, err := q.Client.RPCClient.ABCIInfo(ctx)
 	if err != nil {
@@ -100,8 +93,7 @@ func ABCIInfoRPC(q *Query) (*coretypes.ResultABCIInfo, error) {
 
 // ABCIQueryRPC returns data from a particular path in the ABCI application
 func ABCIQueryRPC(q *Query, path string, data string, prove bool) (*coretypes.ResultABCIQuery, error) {
-	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := q.GetQueryContext()
 	defer cancel()
 	// If height is not specified, default value is 0, query the latest available block then
 	opts := rpcclient.ABCIQueryOptions{

--- a/client/query/tendermint.go
+++ b/client/query/tendermint.go
@@ -1,0 +1,31 @@
+package query
+
+import (
+	"context"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	"time"
+)
+
+// BlockRPC returns information about a block
+func BlockRPC(q *Query) (*coretypes.ResultBlock, error) {
+	var height int64
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// If height is not specified, default value is 0, query the latest available block then
+	if q.Options.Height == 0 {
+		resStatus, err := q.Client.RPCClient.Status(ctx)
+		if err != nil {
+			return nil, err
+		}
+		height = resStatus.SyncInfo.LatestBlockHeight
+	} else {
+		height = q.Options.Height
+	}
+	res, err := q.Client.RPCClient.Block(ctx, &height)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/client/query/tendermint.go
+++ b/client/query/tendermint.go
@@ -2,6 +2,8 @@ package query
 
 import (
 	"context"
+	"encoding/hex"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	"time"
 )
@@ -23,6 +25,90 @@ func BlockRPC(q *Query) (*coretypes.ResultBlock, error) {
 		height = q.Options.Height
 	}
 	res, err := q.Client.RPCClient.Block(ctx, &height)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// BlockByHashRPC returns information about a block by hash
+func BlockByHashRPC(q *Query, hash string) (*coretypes.ResultBlock, error) {
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	h, err := hex.DecodeString(hash)
+	if err != nil {
+		return nil, err
+	}
+	res, err := q.Client.RPCClient.BlockByHash(ctx, h)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// BlockResultsRPC returns information about a block by hash
+func BlockResultsRPC(q *Query) (*coretypes.ResultBlockResults, error) {
+	var height int64
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// If height is not specified, default value is 0, query the latest available block then
+	if q.Options.Height == 0 {
+		resStatus, err := q.Client.RPCClient.Status(ctx)
+		if err != nil {
+			return nil, err
+		}
+		height = resStatus.SyncInfo.LatestBlockHeight
+	} else {
+		height = q.Options.Height
+	}
+	res, err := q.Client.RPCClient.BlockResults(ctx, &height)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// StatusRPC returns information about a node status
+func StatusRPC(q *Query) (*coretypes.ResultStatus, error) {
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	res, err := q.Client.RPCClient.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// ABCIInfoRPC returns information about the ABCI application
+func ABCIInfoRPC(q *Query) (*coretypes.ResultABCIInfo, error) {
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	res, err := q.Client.RPCClient.ABCIInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// ABCIQueryRPC returns data from a particular path in the ABCI application
+func ABCIQueryRPC(q *Query, path string, data string, prove bool) (*coretypes.ResultABCIQuery, error) {
+	timeout, _ := time.ParseDuration(q.Client.Config.Timeout) // Timeout is validated in the config so no error check
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// If height is not specified, default value is 0, query the latest available block then
+	opts := rpcclient.ABCIQueryOptions{
+		Height: q.Options.Height,
+		Prove:  prove,
+	}
+	res, err := q.Client.RPCClient.ABCIQueryWithOptions(ctx, path, []byte(data), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -93,6 +93,7 @@ func distributionQueryCmd() *cobra.Command {
 		distributionCommunityPoolCmd(),
 		distributionRewardsCmd(),
 		distributionSlashesCmd(),
+		distributionDelegatorValidatorsCmd(),
 	)
 
 	return cmd

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -173,7 +173,7 @@ func stakingQueryCmd() *cobra.Command {
 		// stakingRedelegationsCmd(),
 		// stakingValidatorCmd(),
 		// stakingValidatorsCmd(),
-		// stakingValidatorDelegationsCmd(),
+		stakingValidatorDelegationsCmd(),
 		// stakingValidatorUnbondingDelegationsCmd(),
 		// stakingValidatorRedelegationsCmd(),
 		// stakingHistoricalInfoCmd(),

--- a/cmd/staking.go
+++ b/cmd/staking.go
@@ -188,3 +188,39 @@ $ lens query staking delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p co
 
 	return cmd
 }
+
+func stakingValidatorDelegationsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "validator-delegations [validator-addr]",
+		Aliases: []string{"valdel", "vd"},
+		Short:   "query all delegations for a validator address",
+		Long: strings.TrimSpace(`query delegations for an individual validator.
+
+Example:
+$ lens query staking validator-delegations [validator address (valoper)]
+`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl := config.GetDefaultClient()
+			pr, err := sdkclient.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+			height, err := ReadHeight(cmd.Flags())
+			if err != nil {
+				return err
+			}
+			validator := args[0]
+			options := query.QueryOptions{Pagination: pr, Height: height}
+			query := query.Query{cl, &options}
+			response, err := query.ValidatorDelegations(validator)
+			if err != nil {
+				return err
+			}
+			return cl.PrintObject(response)
+		},
+	}
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "validator-delegations")
+	return cmd
+}


### PR DESCRIPTION
Closes: #107

This PR continues the work to refactor the query logic. Implemented additional methods for some modules like distribution and tendermint methods are now part of the query (instead of just in cmd). 

This also includes improvements like hooking up flags to cmd's that didn't have them. 

This refactoring working continues but just wants to submit this work to ensure the branch doesn't diverge too much from main since now there are other people working on the project. 