### PR TITLE
`lens keys enumerate` uses more clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 vendor/
 build/
 *.json
+.DS_Store
 
 # If anyone runs "go build .", ignore the resulting binary.
 lens

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -293,7 +293,7 @@ func keysEnumerateCmd(lc *lensConfig) *cobra.Command {
 		Use:     "enumerate [key-or-address]",
 		Aliases: []string{"e"},
 		Short:   "enumerates the address for a given key across all configured chains",
-		Long:    "if no name is passed, name in config is used",
+		Long:    "if no key or address is passed, the key on the default chain is used to enumerate through all configured chains",
 		Args:    cobra.RangeArgs(0, 1),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys enumerate

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -290,7 +290,7 @@ type KeyEnumeration struct {
 // keysEnumerateCmd respresents the `keys enumerate` command
 func keysEnumerateCmd(lc *lensConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "enumerate [name]",
+		Use:     "enumerate [key-or-address]",
 		Aliases: []string{"e"},
 		Short:   "enumerates the address for a given key across all configured chains",
 		Long:    "if no name is passed, name in config is used",


### PR DESCRIPTION
Closes #9 
`lens keys enumerate` already works with a key or address as input
Just making it more clear to users.