### PR TITLE
Explicitly pass context to chain registry methods

### DIFF
--- a/client/chain_registry/chain_registry.go
+++ b/client/chain_registry/chain_registry.go
@@ -1,8 +1,10 @@
 package chain_registry
 
+import "context"
+
 type ChainRegistry interface {
-	GetChain(name string) (ChainInfo, error)
-	ListChains() ([]string, error)
+	GetChain(ctx context.Context, name string) (ChainInfo, error)
+	ListChains(ctx context.Context) ([]string, error)
 	SourceLink() string
 }
 

--- a/client/chain_registry/cosmos_github_registry.go
+++ b/client/chain_registry/cosmos_github_registry.go
@@ -15,11 +15,13 @@ import (
 
 type CosmosGithubRegistry struct{}
 
-func (c CosmosGithubRegistry) ListChains() ([]string, error) {
+func (c CosmosGithubRegistry) ListChains(ctx context.Context) ([]string, error) {
 	client := github.NewClient(http.DefaultClient)
 	var chains []string
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+
 	tree, res, err := client.Git.GetTree(
 		ctx,
 		"cosmos",
@@ -38,12 +40,12 @@ func (c CosmosGithubRegistry) ListChains() ([]string, error) {
 	return chains, nil
 }
 
-func (c CosmosGithubRegistry) GetChain(name string) (ChainInfo, error) {
+func (c CosmosGithubRegistry) GetChain(ctx context.Context, name string) (ChainInfo, error) {
 	client := github.NewClient(http.DefaultClient)
 
 	chainFileName := path.Join(name, "chain.json")
 	fileContent, _, res, err := client.Repositories.GetContents(
-		context.Background(),
+		ctx,
 		"cosmos",
 		"chain-registry",
 		chainFileName,

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -45,7 +45,7 @@ func cmdChainsRegistryList(lc *lensConfig) *cobra.Command {
 		Aliases: []string{"rl"},
 		Short:   "list chains available for configuration from the registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chains, err := chain_registry.DefaultChainRegistry().ListChains()
+			chains, err := chain_registry.DefaultChainRegistry().ListChains(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -63,7 +63,7 @@ func cmdChainsAdd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 		Short:   "add configuration for a chain or a number of chains from the chain registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registry := chain_registry.DefaultChainRegistry()
-			allChains, err := registry.ListChains()
+			allChains, err := registry.ListChains(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -81,13 +81,13 @@ func cmdChainsAdd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 					continue
 				}
 
-				chainInfo, err := registry.GetChain(chain)
+				chainInfo, err := registry.GetChain(cmd.Context(), chain)
 				if err != nil {
 					log.Printf("error getting chain: %s", err)
 					continue
 				}
 
-				chainConfig, err := chainInfo.GetChainConfig()
+				chainConfig, err := chainInfo.GetChainConfig(cmd.Context())
 				if err != nil {
 					log.Printf("error generating chain config: %s", err)
 					continue


### PR DESCRIPTION
Creating a context.Background inside a method is generally an
anti-pattern. Instead, accept a context as an argument to the method, so
that a top-level caller can provide a meaningful root context -- in this
case, a context associated with the *cobra.Command.