### PR TITLE
Move lensConfig and viper into appState struct

### DIFF
--- a/cmd/airdrop.go
+++ b/cmd/airdrop.go
@@ -13,14 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func airdropCmd(lc *lensConfig) *cobra.Command {
+func airdropCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "airdrop [airdrop.json] [denom] [exclude] [key]?",
 		Short: "Airdrop coins to a specified address",
 		Long:  "The airdrop file consists of map[string]float64 where the key is the address on the target chain and the value is the amount of coins to be airdropped to that address/1e6 (i.e. atom instead of uatom). The airdrop command 1. checks the addresses in the file to ensure that they are valid for the given chain l",
 		Args:  cobra.RangeArgs(3, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			keyNameOrAddress := ""
 			if len(args) == 3 {
 				keyNameOrAddress = cl.Config.Key

--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"path"
+
+	"github.com/spf13/viper"
+)
+
+// appState is the modifiable state of the application.
+type appState struct {
+	Viper *viper.Viper
+
+	HomePath        string
+	OverriddenChain string
+	Debug           bool
+	Config          *Config
+}
+
+// OverwriteConfig overwrites the config files on disk with the serialization of cfg,
+// and it replaces a.Config with cfg.
+//
+// It is possible to use a brand new Config argument,
+// but typically the argument is a.Config.
+func (a *appState) OverwriteConfig(cfg *Config) error {
+	home := a.Viper.GetString("home")
+	cfgPath := path.Join(home, "config.yaml")
+	if err := os.WriteFile(cfgPath, cfg.MustYAML(), 0600); err != nil {
+		return err
+	}
+
+	a.Config = cfg
+	log.Printf("updated lens configuration at %s", cfgPath)
+	return nil
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func authAccountCmd(lc *lensConfig) *cobra.Command {
+func authAccountCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "account [address]",
 		Aliases: []string{"acc"},
 		Short:   "query an account for its number and sequence or pass no arguement to query default account",
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			keyNameOrAddress := ""
 			if len(args) == 0 {
 				keyNameOrAddress = cl.Config.Key
@@ -35,14 +34,14 @@ func authAccountCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func authAccountsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func authAccountsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "accounts",
 		Aliases: []string{"accs"},
 		Short:   "query all accounts on a given chain w/ pagination",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -55,17 +54,17 @@ func authAccountsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			return cl.PrintObject(res)
 		},
 	}
-	return paginationFlags(cmd, v)
+	return paginationFlags(cmd, a.Viper)
 }
 
-func authParamsCmd(lc *lensConfig) *cobra.Command {
+func authParamsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "parameters",
 		Aliases: []string{"param", "params", "p"},
 		Short:   "query the current auth parameters",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			res, err := authtypes.NewQueryClient(cl).Params(cmd.Context(), &authtypes.QueryParamsRequest{})
 			if err != nil {
 				return err

--- a/cmd/authz.go
+++ b/cmd/authz.go
@@ -3,10 +3,9 @@ package cmd
 import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func authzGrantsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func authzGrantsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grants [grantor] [grantee] [msg_type]?",
 		Aliases: []string{"grants"},
@@ -17,7 +16,7 @@ func authzGrantsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			// and the grantee client. This will allow for use of a
 			// ledger as the grantor (i.e. cosmoshub-ledger in the config)
 			// and test keyringbacked for the grantee (i.e. cosmoshub)
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -53,14 +52,14 @@ func authzGrantsCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			return cl.PrintObject(res)
 		},
 	}
-	return paginationFlags(cmd, v)
+	return paginationFlags(cmd, a.Viper)
 }
 
 // TODO: rethink UX here. We should break this up into a number
 // of smaller commands. For example, we should have a grantSend,
 // grantStake, grantWithdraw, grantVote, grantValidator, etc...
 // authzGrantAuthorizationCmd returns the authz grant authorization command for this module
-func authzGrantAuthorizationCmd(lc *lensConfig) *cobra.Command {
+func authzGrantAuthorizationCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grant [grantor] [grantee] [role]",
 		Aliases: []string{"grant"},
@@ -89,7 +88,7 @@ func authzGrantAuthorizationCmd(lc *lensConfig) *cobra.Command {
 }
 
 // authzRevokeAuthorizationCmd returns the authz revoke authorization command for this module
-func authzRevokeAuthorizationCmd(lc *lensConfig) *cobra.Command {
+func authzRevokeAuthorizationCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "revoke [grantee] [msg_type] [grantor]?",
 		Aliases: []string{"r"},
@@ -100,7 +99,7 @@ func authzRevokeAuthorizationCmd(lc *lensConfig) *cobra.Command {
 			// and the grantee client. This will allow for use of a
 			// ledger as the grantor (i.e. cosmoshub-ledger in the config)
 			// and test keyringbacked for the grantee (i.e. cosmoshub)
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			var key string
 			if len(args) == 3 {
 				key = args[2]
@@ -128,7 +127,7 @@ func authzRevokeAuthorizationCmd(lc *lensConfig) *cobra.Command {
 }
 
 // authzExecAuthorizationCmd returns the authz exec authorization command for this module
-func authzExecAuthorizationCmd(lc *lensConfig) *cobra.Command {
+func authzExecAuthorizationCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "exec [msg_tx_json_file] [grantee]?",
 		Aliases: []string{"exec"},

--- a/cmd/bank.go
+++ b/cmd/bank.go
@@ -10,13 +10,13 @@ import (
 	query "github.com/strangelove-ventures/lens/client/query"
 )
 
-func bankSendCmd(lc *lensConfig) *cobra.Command {
+func bankSendCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send [from] [to] [amount]",
 		Short: "send coins from one address to another",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			fromAddr, err := cl.AccountFromKeyOrAddress(args[0])
 			if err != nil {
 				return err
@@ -54,14 +54,14 @@ func bankSendCmd(lc *lensConfig) *cobra.Command {
 
 // ========== Querier Functions ==========
 
-func bankBalanceCmd(lc *lensConfig) *cobra.Command {
+func bankBalanceCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "balances [key-or-address]",
 		Aliases: []string{"bal", "b"},
 		Short:   "query the account balance for a key or address (if none is specified, the balance of the default account is returned)",
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -95,14 +95,14 @@ func bankBalanceCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func bankTotalSupplyCmd(lc *lensConfig) *cobra.Command {
+func bankTotalSupplyCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "total-supply",
 		Aliases: []string{"totalsupply", "tot", "ts", "totsupplys"},
 		Short:   "query the total supply of coins in the chain",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -125,14 +125,14 @@ func bankTotalSupplyCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func bankDenomsMetadataCmd(lc *lensConfig) *cobra.Command {
+func bankDenomsMetadataCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "denoms-metadata",
 		Aliases: []string{"denoms", "d"},
 		Short:   "query the denoms metadata",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err

--- a/cmd/crosschain.go
+++ b/cmd/crosschain.go
@@ -11,7 +11,7 @@ import (
 )
 
 // crosschainCmd represents the command to get balances across chains
-func crosschainCmd(lc *lensConfig) *cobra.Command {
+func crosschainCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "crosschain",
 		Aliases: []string{"cc", "kriskross", "cchain", "coolchain"},
@@ -19,7 +19,7 @@ func crosschainCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		crosschainBankQueryCmd(lc),
+		crosschainBankQueryCmd(a),
 	)
 
 	cmd.PersistentFlags().Bool("combined", false, "combine balances from all chains")
@@ -28,7 +28,7 @@ func crosschainCmd(lc *lensConfig) *cobra.Command {
 }
 
 // crosschainBankQueryCmd returns the transaction commands for this module
-func crosschainBankQueryCmd(lc *lensConfig) *cobra.Command {
+func crosschainBankQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b"},
@@ -36,13 +36,13 @@ func crosschainBankQueryCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		getEnabledChainbalancesCmd(lc),
+		getEnabledChainbalancesCmd(a),
 	)
 
 	return cmd
 }
 
-func getEnabledChainbalancesCmd(lc *lensConfig) *cobra.Command {
+func getEnabledChainbalancesCmd(a *appState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "balances [key-or-address]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -54,14 +54,14 @@ func getEnabledChainbalancesCmd(lc *lensConfig) *cobra.Command {
 				return err
 			}
 			enabledChains := []string{}
-			for chain := range lc.config.Chains {
+			for chain := range a.Config.Chains {
 				enabledChains = append(enabledChains, chain)
 			}
 			// alphabetically sort the chains - this is to make the output more readable/consistent
 			sort.StringSlice(enabledChains).Sort()
 
 			// copied from bank.go
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			var (
 				keyNameOrAddress = ""
 				address          sdk.AccAddress
@@ -83,7 +83,7 @@ func getEnabledChainbalancesCmd(lc *lensConfig) *cobra.Command {
 			denomBalanceMap := make(map[string]sdk.Coins)
 			// end: copied from bank.go
 			for _, chain := range enabledChains {
-				cl := lc.config.GetClient(chain)
+				cl := a.Config.GetClient(chain)
 				balance, err := cl.QueryBalanceWithDenomTraces(cmd.Context(), address, client.DefaultPageRequest())
 				if err != nil {
 					return err
@@ -110,7 +110,7 @@ func getEnabledChainbalancesCmd(lc *lensConfig) *cobra.Command {
 				}
 			} else {
 				for _, chain := range enabledChains {
-					cl := lc.config.GetClient(chain)
+					cl := a.Config.GetClient(chain)
 					chainAddress, err := cl.EncodeBech32AccAddr(address)
 					if err != nil {
 						return err

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -2,15 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/strangelove-ventures/lens/client/query"
 	"strconv"
 	"strings"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/strangelove-ventures/lens/client/query"
 )
 
 const (
@@ -22,7 +21,7 @@ const (
 // if so then we should make the first arg mandatory and further args be []sdk.ValAddr
 // and make the []sdk.ValAddr optional. This way we don't need any of the flags except
 // commission
-func distributionWithdrawRewardsCmd(lc *lensConfig) *cobra.Command {
+func distributionWithdrawRewardsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "withdraw-rewards [validator-addr] [from]",
 		Short: "Withdraw rewards from a given delegation address, and optionally withdraw validator commission if the delegation address given is a validator operator",
@@ -37,7 +36,7 @@ $ lens tx withdraw-rewards --from mykey --all
 		),
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			key := ""
 			if len(args) == 1 {
 				key = cl.Config.Key
@@ -95,12 +94,12 @@ $ lens tx withdraw-rewards --from mykey --all
 	return cmd
 }
 
-func distributionParamsCmd(lc *lensConfig) *cobra.Command {
+func distributionParamsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "query things about a chain's distribution params",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 
 			params, err := cl.QueryDistributionParams(cmd.Context())
 			if err != nil {
@@ -114,12 +113,12 @@ func distributionParamsCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func distributionCommunityPoolCmd(lc *lensConfig) *cobra.Command {
+func distributionCommunityPoolCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "community-pool",
 		Short: "query things about a chain's community pool",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 
 			pool, err := cl.QueryDistributionCommunityPool(cmd.Context())
 			if err != nil {
@@ -133,13 +132,13 @@ func distributionCommunityPoolCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func distributionCommissionCmd(lc *lensConfig) *cobra.Command {
+func distributionCommissionCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commission [validator-address]",
 		Args:  cobra.ExactArgs(1),
 		Short: "query a specific validator's commission",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			address, err := cl.DecodeBech32ValAddr(args[0])
 			if err != nil {
 				return err
@@ -157,13 +156,13 @@ func distributionCommissionCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func distributionRewardsCmd(lc *lensConfig) *cobra.Command {
+func distributionRewardsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rewards [key-or-delegator-address] [validator-address]",
 		Short: "query things about a delegator's rewards",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			delAddr, err := cl.AccountFromKeyOrAddress(args[0])
 			if err != nil {
 				return err
@@ -186,13 +185,13 @@ func distributionRewardsCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func distributionSlashesCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func distributionSlashesCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "slashes [validator-address] [start-height] [end-height]",
 		Short: "query things about a validator's slashes on a chain",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -223,16 +222,16 @@ func distributionSlashesCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 		},
 	}
 
-	return paginationFlags(cmd, v)
+	return paginationFlags(cmd, a.Viper)
 }
 
-func distributionValidatorRewardsCmd(lc *lensConfig) *cobra.Command {
+func distributionValidatorRewardsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validator-outstanding-rewards [address]",
 		Short: "query things about a validator's (and all their delegators) outstanding rewards on a chain",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 
 			address, err := cl.DecodeBech32ValAddr(args[0])
 			if err != nil {
@@ -250,7 +249,7 @@ func distributionValidatorRewardsCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func distributionDelegatorValidatorsCmd(lc *lensConfig) *cobra.Command {
+func distributionDelegatorValidatorsCmd(a *appState) *cobra.Command {
 	var delegator string
 	cmd := &cobra.Command{
 		Use:     "delegator-validators [delegator_address]",
@@ -270,7 +269,7 @@ func distributionDelegatorValidatorsCmd(lc *lensConfig) *cobra.Command {
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			// Check if the address has a valid format
 			if len(delegator) > 0 {
 				_, err := cl.DecodeBech32AccAddr(delegator)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // queryCmd represents the query command tree.
-func queryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func queryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "query",
 		Aliases: []string{"q"},
@@ -14,11 +13,11 @@ func queryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authQueryCmd(v, lc),
-		authzQueryCmd(v, lc),
-		bankQueryCmd(lc),
-		distributionQueryCmd(v, lc),
-		stakingQueryCmd(lc),
+		authQueryCmd(a),
+		authzQueryCmd(a),
+		bankQueryCmd(a),
+		distributionQueryCmd(a),
+		stakingQueryCmd(a),
 	)
 
 	if false {
@@ -34,7 +33,7 @@ func queryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 }
 
 // authQueryCmd returns the transaction commands for this module
-func authQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func authQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "auth",
 		Aliases: []string{"a"},
@@ -42,16 +41,16 @@ func authQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authAccountCmd(lc),
-		authAccountsCmd(v, lc),
-		authParamsCmd(lc),
+		authAccountCmd(a),
+		authAccountsCmd(a),
+		authParamsCmd(a),
 	)
 
 	return cmd
 }
 
 // authzQueryCmd returns the authz query commands for this module
-func authzQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func authzQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "authz",
 		Aliases: []string{"authz"},
@@ -59,14 +58,14 @@ func authzQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authzGrantsCmd(v, lc),
+		authzGrantsCmd(a),
 	)
 
 	return cmd
 }
 
 // bankQueryCmd  returns the transaction commands for this module
-func bankQueryCmd(lc *lensConfig) *cobra.Command {
+func bankQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b"},
@@ -74,16 +73,16 @@ func bankQueryCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		bankBalanceCmd(lc),
-		bankTotalSupplyCmd(lc),
-		bankDenomsMetadataCmd(lc),
+		bankBalanceCmd(a),
+		bankTotalSupplyCmd(a),
+		bankDenomsMetadataCmd(a),
 	)
 
 	return cmd
 }
 
 // distributionQueryCmd returns the distribution query commands for this module
-func distributionQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func distributionQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "distribution",
 		Aliases: []string{"dist", "distr", "d"},
@@ -91,13 +90,13 @@ func distributionQueryCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		distributionParamsCmd(lc),
-		distributionValidatorRewardsCmd(lc),
-		distributionCommissionCmd(lc),
-		distributionCommunityPoolCmd(lc),
-		distributionRewardsCmd(lc),
-		distributionSlashesCmd(v, lc),
-		distributionDelegatorValidatorsCmd(lc),
+		distributionParamsCmd(a),
+		distributionValidatorRewardsCmd(a),
+		distributionCommissionCmd(a),
+		distributionCommunityPoolCmd(a),
+		distributionRewardsCmd(a),
+		distributionSlashesCmd(a),
+		distributionDelegatorValidatorsCmd(a),
 	)
 
 	return cmd
@@ -161,7 +160,7 @@ func slashingQueryCmd() *cobra.Command {
 }
 
 // stakingQueryCmd returns the staking query commands for this module
-func stakingQueryCmd(lc *lensConfig) *cobra.Command {
+func stakingQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "staking",
 		Aliases: []string{"stake", "s"},
@@ -169,15 +168,15 @@ func stakingQueryCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		stakingDelegationCmd(lc),
-		stakingDelegationsCmd(lc),
+		stakingDelegationCmd(a),
+		stakingDelegationsCmd(a),
 		// stakingUnbondingDelegationCmd(),
 		// stakingUnbondingDelegationsCmd(),
 		// stakingRedelegationCmd(),
 		// stakingRedelegationsCmd(),
 		// stakingValidatorCmd(),
 		// stakingValidatorsCmd(),
-		stakingValidatorDelegationsCmd(lc),
+		stakingValidatorDelegationsCmd(a),
 		// stakingValidatorUnbondingDelegationsCmd(),
 		// stakingValidatorRedelegationsCmd(),
 		// stakingHistoricalInfoCmd(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,22 +28,15 @@ import (
 
 const appName = "lens"
 
-type lensConfig struct {
-	homePath       string
-	overridenChain string
-	debug          bool
-	config         Config
-}
-
 // NewRootCmd returns the root command for relayer.
 func NewRootCmd() *cobra.Command {
-	// Use a local viper instance scoped to a root command,
-	// so that tests don't concurrently access a single viper instance.
-	v := viper.New()
+	// Use a local app state instance scoped to the new root command,
+	// so that tests don't concurrently access the state.
+	a := &appState{
+		Viper: viper.New(),
+	}
 
 	defaultHome := os.ExpandEnv("$HOME/.lens")
-
-	var lc lensConfig
 
 	// RootCmd represents the base command when called without any subcommands
 	var rootCmd = &cobra.Command{
@@ -53,7 +46,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		// reads `homeDir/config.yaml` into `var config *Config` before each command
-		if err := initConfig(rootCmd, v, &lc); err != nil {
+		if err := initConfig(rootCmd, a); err != nil {
 			return err
 		}
 
@@ -61,36 +54,36 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	// --home flag
-	rootCmd.PersistentFlags().StringVar(&lc.homePath, flags.FlagHome, defaultHome, "set home directory")
-	if err := v.BindPFlag(flags.FlagHome, rootCmd.PersistentFlags().Lookup(flags.FlagHome)); err != nil {
+	rootCmd.PersistentFlags().StringVar(&a.HomePath, flags.FlagHome, defaultHome, "set home directory")
+	if err := a.Viper.BindPFlag(flags.FlagHome, rootCmd.PersistentFlags().Lookup(flags.FlagHome)); err != nil {
 		panic(err)
 	}
 
 	// --debug flag
-	rootCmd.PersistentFlags().BoolVarP(&lc.debug, "debug", "d", false, "debug output")
-	if err := v.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+	rootCmd.PersistentFlags().BoolVarP(&a.Debug, "debug", "d", false, "debug output")
+	if err := a.Viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		panic(err)
 	}
 
 	rootCmd.PersistentFlags().StringP("output", "o", "json", "output format (json, indent, yaml)")
-	if err := v.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output")); err != nil {
+	if err := a.Viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output")); err != nil {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringVar(&lc.overridenChain, "chain", "", "override default chain")
-	if err := v.BindPFlag("chain", rootCmd.PersistentFlags().Lookup("chain")); err != nil {
+	rootCmd.PersistentFlags().StringVar(&a.OverriddenChain, "chain", "", "override default chain")
+	if err := a.Viper.BindPFlag("chain", rootCmd.PersistentFlags().Lookup("chain")); err != nil {
 		panic(err)
 	}
 
 	rootCmd.AddCommand(
-		chainsCmd(v, &lc),
-		keysCmd(v, &lc),
-		queryCmd(v, &lc),
-		tendermintCmd(v, &lc),
-		crosschainCmd(&lc),
-		txCmd(&lc),
+		chainsCmd(a),
+		keysCmd(a),
+		queryCmd(a),
+		tendermintCmd(a),
+		crosschainCmd(a),
+		txCmd(a),
 		versionCmd(),
-		airdropCmd(&lc),
+		airdropCmd(a),
 	)
 
 	return rootCmd

--- a/cmd/staking.go
+++ b/cmd/staking.go
@@ -11,7 +11,7 @@ import (
 	"github.com/strangelove-ventures/lens/client/query"
 )
 
-func stakingDelegateCmd(lc *lensConfig) *cobra.Command {
+func stakingDelegateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegate [validator-addr] [amount] ",
 		Args:  cobra.ExactArgs(2),
@@ -28,7 +28,7 @@ $ lens tx staking delegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0 
 				err     error
 			)
 
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 
 			if args[2] != cl.Config.Key {
 				cl.Config.Key = args[2]
@@ -76,7 +76,7 @@ $ lens tx staking delegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0 
 	return cmd
 }
 
-func stakingRedelegateCmd(lc *lensConfig) *cobra.Command {
+func stakingRedelegateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redelegate [from] [src-validator-addr] [dst-validator-addr] [amount]",
 		Short: "redelegate tokens from one validator to another",
@@ -88,7 +88,7 @@ $ lens tx staking redelegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj
 `,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			key, _ := cmd.Flags().GetString(FlagFrom)
 			delAddr, err := cl.AccountFromKeyOrAddress(key)
 			if err != nil {
@@ -126,7 +126,7 @@ $ lens tx staking redelegate cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj
 	return cmd
 }
 
-func stakingDelegationsCmd(lc *lensConfig) *cobra.Command {
+func stakingDelegationsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegations [delegator-addr]",
 		Short: "query all delegations for a delegator address",
@@ -137,7 +137,7 @@ $ lens query staking delegations cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 `),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := sdkclient.ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
@@ -160,7 +160,7 @@ $ lens query staking delegations cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 	return cmd
 }
 
-func stakingDelegationCmd(lc *lensConfig) *cobra.Command {
+func stakingDelegationCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegation [delegator-addr] [validator-addr]",
 		Short: "query a delegation based on a delegator address and validator address",
@@ -171,7 +171,7 @@ $ lens query staking delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p co
 `),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			cq := query.Query{Client: cl, Options: query.DefaultOptions()}
 			delegator := args[0]
 			validator := args[1]
@@ -188,7 +188,7 @@ $ lens query staking delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p co
 	return cmd
 }
 
-func stakingValidatorDelegationsCmd(lc *lensConfig) *cobra.Command {
+func stakingValidatorDelegationsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "validator-delegations [validator-addr]",
 		Aliases: []string{"valdel", "vd"},
@@ -200,7 +200,7 @@ $ lens query staking validator-delegations [validator address (valoper)]
 `),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			pr, err := sdkclient.ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err

--- a/cmd/tendermint.go
+++ b/cmd/tendermint.go
@@ -18,51 +18,50 @@ package cmd
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/strangelove-ventures/lens/client"
-	"github.com/strangelove-ventures/lens/client/query"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/strangelove-ventures/lens/client"
+	"github.com/strangelove-ventures/lens/client/query"
 )
 
 // tendermintCmd represents the tendermint command
-func tendermintCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func tendermintCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "tendermint",
 		Aliases: []string{"tm"},
 		Short:   "all tendermint query commands",
 	}
 	cmd.AddCommand(
-		abciInfoCmd(lc),
-		abciQueryCmd(lc),
-		blockCmd(lc),
-		blockByHashCmd(lc),
-		blockResultsCmd(lc),
+		abciInfoCmd(a),
+		abciQueryCmd(a),
+		blockCmd(a),
+		blockByHashCmd(a),
+		blockResultsCmd(a),
 		blockSearchCmd(),
-		consensusParamsCmd(lc),
-		consensusStateCmd(lc),
-		dumpConsensusStateCmd(lc),
-		healthCmd(lc),
-		netInfoCmd(v, lc),
-		numUnconfirmedTxs(v, lc),
-		statusCmd(lc),
-		queryTxCmd(v, lc),
+		consensusParamsCmd(a),
+		consensusStateCmd(a),
+		dumpConsensusStateCmd(a),
+		healthCmd(a),
+		netInfoCmd(a),
+		numUnconfirmedTxs(a),
+		statusCmd(a),
+		queryTxCmd(a),
 	)
 	return cmd
 }
 
-func abciInfoCmd(lc *lensConfig) *cobra.Command {
+func abciInfoCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "abci-info",
 		Aliases: []string{"abcii"},
 		Short:   "queries for block height, app name and app hash",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			query := query.Query{Client: cl, Options: query.DefaultOptions()}
 
 			res, err := query.ABCIInfo()
@@ -75,14 +74,14 @@ func abciInfoCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func abciQueryCmd(lc *lensConfig) *cobra.Command {
+func abciQueryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "abci-query [path] [data] [height]",
 		Aliases: []string{"qabci"},
 		Short:   "query the abci interface for tendermint directly",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			path := args[0]
 			data := args[1]
 			prove := false // TODO: Hookup to a flag
@@ -103,14 +102,14 @@ func abciQueryCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func blockCmd(lc *lensConfig) *cobra.Command {
+func blockCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "block",
 		Aliases: []string{"bl", "blk"},
 		Short:   "query tendermint data for a block at a given height",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			height, err := ReadHeight(cmd.Flags())
 			if err != nil {
 				return err
@@ -129,14 +128,14 @@ func blockCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func blockByHashCmd(lc *lensConfig) *cobra.Command {
+func blockByHashCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "block-by-hash [hash]",
 		Aliases: []string{"blhash", "blh", "bbh"},
 		Short:   "query tendermint for a given block by hash",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			query := query.Query{Client: cl, Options: query.DefaultOptions()}
 			hash := args[0]
 			res, err := query.BlockByHash(hash)
@@ -149,14 +148,14 @@ func blockByHashCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func blockResultsCmd(lc *lensConfig) *cobra.Command {
+func blockResultsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "block-results",
 		Aliases: []string{"blres"},
 		Short:   "query tendermint tx results for a given block by height",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			height, err := ReadHeight(cmd.Flags())
 			if err != nil {
 				return err
@@ -191,7 +190,7 @@ func blockSearchCmd() *cobra.Command {
 	return cmd
 }
 
-func consensusParamsCmd(lc *lensConfig) *cobra.Command {
+func consensusParamsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: make this use a height flag and make height arg optional
 		Use:     "consensus-params [height]",
@@ -199,7 +198,7 @@ func consensusParamsCmd(lc *lensConfig) *cobra.Command {
 		Short:   "query tendermint consensus params at a given height",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			height, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return err
@@ -218,7 +217,7 @@ func consensusParamsCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func consensusStateCmd(lc *lensConfig) *cobra.Command {
+func consensusStateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: add special flag to this for network startup
 		// that runs query on timer and shows a progress bar
@@ -228,7 +227,7 @@ func consensusStateCmd(lc *lensConfig) *cobra.Command {
 		Short:   "query current tendermint consensus state",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			block, err := cl.RPCClient.ConsensusState(cmd.Context())
 			if err != nil {
 				return err
@@ -242,14 +241,14 @@ func consensusStateCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func dumpConsensusStateCmd(lc *lensConfig) *cobra.Command {
+func dumpConsensusStateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dump-consensus-state",
 		Aliases: []string{"dump-cs", "csdump", "cs-dump", "dumpcs"},
 		Short:   "query detailed version of current tendermint consensus state",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			block, err := cl.RPCClient.DumpConsensusState(cmd.Context())
 			if err != nil {
 				return err
@@ -263,14 +262,14 @@ func dumpConsensusStateCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func healthCmd(lc *lensConfig) *cobra.Command {
+func healthCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "health",
 		Aliases: []string{"h", "ok"},
 		Short:   "query to see if node server is online",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			block, err := cl.RPCClient.Health(cmd.Context())
 			if err != nil {
 				return err
@@ -284,7 +283,7 @@ func healthCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func netInfoCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func netInfoCmd(a *appState) *cobra.Command {
 	// TODO: add flag for pulling out comma seperated list of peers
 	// and also filter out private IPs and other ill formed peers
 	// _{*extraCredit*}_
@@ -294,7 +293,7 @@ func netInfoCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 		Short:   "query for p2p network connection information",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			peers, err := cmd.Flags().GetBool("peers")
 			if err != nil {
 				return err
@@ -322,10 +321,10 @@ func netInfoCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			return nil
 		},
 	}
-	return peersFlag(cmd, v)
+	return peersFlag(cmd, a.Viper)
 }
 
-func numUnconfirmedTxs(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func numUnconfirmedTxs(a *appState) *cobra.Command {
 	// TODO: add example for parsing these txs
 	// _{*extraCredit*}_
 	cmd := &cobra.Command{
@@ -334,7 +333,7 @@ func numUnconfirmedTxs(v *viper.Viper, lc *lensConfig) *cobra.Command {
 		Short:   "query for number of unconfirmed txs",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			limit, err := cmd.Flags().GetInt("limit")
 			if err != nil {
 				return err
@@ -352,17 +351,17 @@ func numUnconfirmedTxs(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			return nil
 		},
 	}
-	return limitFlag(cmd, v)
+	return limitFlag(cmd, a.Viper)
 }
 
-func statusCmd(lc *lensConfig) *cobra.Command {
+func statusCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status",
 		Aliases: []string{"stat", "s"},
 		Short:   "query the status of a node",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			query := query.Query{Client: cl, Options: query.DefaultOptions()}
 
 			status, err := query.Status()
@@ -375,13 +374,13 @@ func statusCmd(lc *lensConfig) *cobra.Command {
 	return cmd
 }
 
-func queryTxCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
+func queryTxCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx [hash]",
 		Short: "query for a transaction by hash",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cl := lc.config.GetDefaultClient()
+			cl := a.Config.GetDefaultClient()
 			prove, err := cmd.Flags().GetBool("prove")
 			if err != nil {
 				return err
@@ -397,5 +396,5 @@ func queryTxCmd(v *viper.Viper, lc *lensConfig) *cobra.Command {
 			return cl.PrintObject(block)
 		},
 	}
-	return proveFlag(cmd, v)
+	return proveFlag(cmd, a.Viper)
 }

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -5,7 +5,7 @@ import (
 )
 
 // TxCommand registers a new tx command.
-func txCmd(lc *lensConfig) *cobra.Command {
+func txCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx",
 		Short: "broadcast transactions to a chain",
@@ -13,12 +13,12 @@ func txCmd(lc *lensConfig) *cobra.Command {
 
 	cmd.AddCommand(
 		authTxCmd(),
-		authzTxCmd(lc),
-		bankTxCmd(lc),
-		distributionTxCmd(lc),
+		authzTxCmd(a),
+		bankTxCmd(a),
+		distributionTxCmd(a),
 		feegrantTxCmd(),
 		govTxCmd(),
-		stakingTxCmd(lc),
+		stakingTxCmd(a),
 		slashingTxCmd(),
 	)
 
@@ -40,7 +40,7 @@ func authTxCmd() *cobra.Command {
 }
 
 // authzTxCmd returns the authz tx commands for this module
-func authzTxCmd(lc *lensConfig) *cobra.Command {
+func authzTxCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "authz",
 		Aliases: []string{"az"},
@@ -48,29 +48,29 @@ func authzTxCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		authzGrantAuthorizationCmd(lc),
-		authzRevokeAuthorizationCmd(lc),
-		authzExecAuthorizationCmd(lc),
+		authzGrantAuthorizationCmd(a),
+		authzRevokeAuthorizationCmd(a),
+		authzExecAuthorizationCmd(a),
 	)
 
 	return cmd
 }
 
 // bankTxCmd returns the bank tx commands for this module
-func bankTxCmd(lc *lensConfig) *cobra.Command {
+func bankTxCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bank",
 		Aliases: []string{"b", "bnk"},
 		Short:   "bank transaction commands",
 	}
 
-	cmd.AddCommand(bankSendCmd(lc))
+	cmd.AddCommand(bankSendCmd(a))
 
 	return cmd
 }
 
 // distributionTxCmd returns the distribution tx commands for this module
-func distributionTxCmd(lc *lensConfig) *cobra.Command {
+func distributionTxCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "distribution",
 		Aliases: []string{"dist", "distr", "d"},
@@ -78,7 +78,7 @@ func distributionTxCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		distributionWithdrawRewardsCmd(lc),
+		distributionWithdrawRewardsCmd(a),
 		// distributionSetWithdrawAddressCmd(),
 		// distributionFundCommunityPoolCmd(),
 	)
@@ -103,7 +103,7 @@ func feegrantTxCmd() *cobra.Command {
 }
 
 // stakingTxCmd returns the staking tx commands for this module
-func stakingTxCmd(lc *lensConfig) *cobra.Command {
+func stakingTxCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "staking",
 		Aliases: []string{"stake", "stk"},
@@ -111,8 +111,8 @@ func stakingTxCmd(lc *lensConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		stakingDelegateCmd(lc),
-		stakingRedelegateCmd(lc),
+		stakingDelegateCmd(a),
+		stakingRedelegateCmd(a),
 		// stakingCreateValidatorCmd(),
 		// stakingEditValidatorCmd(),
 		// stakingUnbondCmd(),


### PR DESCRIPTION
This is just a mechanical refactor pushing both values, which we need in
many commands, into a single struct. Any future needed "global" settings
can live in appState too.