### PR TITLE
Add some tests for tendermint commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -91,7 +91,7 @@ func defaultConfig(keyHome string, debug bool) []byte {
 
 // initConfig reads in config file and ENV variables if set.
 // This is called as a persistent pre-run command of the root command.
-func initConfig(cmd *cobra.Command, a *appState) error {
+func initConfig(cmd *cobra.Command, a *appState, o map[string]ClientOverrides) error {
 	home, err := cmd.PersistentFlags().GetString(flags.FlagHome)
 	if err != nil {
 		return err
@@ -136,6 +136,15 @@ func initConfig(cmd *cobra.Command, a *appState) error {
 		cl, err := client.NewChainClient(chain, home, cmd.InOrStdin(), cmd.OutOrStdout())
 		if err != nil {
 			return fmt.Errorf("error creating chain client: %w", err)
+		}
+		// If overrides are present (should only happen in test), modify the client to use those overrides.
+		if o != nil {
+			if rc := o[name].RPCClient; rc != nil {
+				cl.RPCClient = rc
+			}
+			if lp := o[name].LightProvider; lp != nil {
+				cl.LightProvider = lp
+			}
 		}
 		a.Config.cl[name] = cl
 	}

--- a/cmd/system_test.go
+++ b/cmd/system_test.go
@@ -11,6 +11,8 @@ import (
 // System is a system under test.
 type System struct {
 	HomeDir string
+
+	clientOverrides map[string]cmd.ClientOverrides
 }
 
 // NewSystem creates a new system with a home dir associated with a temp dir belonging to t.
@@ -26,6 +28,15 @@ func NewSystem(t *testing.T) *System {
 	return &System{
 		HomeDir: homeDir,
 	}
+}
+
+// OverrideClients sets the client override mapping for the chain with the given name.
+// This override applies to all subsequent command invocations for this System.
+func (s *System) OverrideClients(name string, o cmd.ClientOverrides) {
+	if s.clientOverrides == nil {
+		s.clientOverrides = map[string]cmd.ClientOverrides{}
+	}
+	s.clientOverrides[name] = o
 }
 
 // RunResult is the stdout and stderr resulting from a call to (*System).Run,
@@ -45,7 +56,7 @@ func (s *System) Run(args ...string) RunResult {
 // providing in as the command's standard input,
 // and returns a RunResult that has its Stdout and Stderr populated.
 func (s *System) RunWithInput(in io.Reader, args ...string) RunResult {
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewRootCmd(s.clientOverrides)
 	rootCmd.SetIn(in)
 	// cmd.Execute also sets SilenceUsage,
 	// so match that here for more correct assertions.

--- a/cmd/tendermint_test.go
+++ b/cmd/tendermint_test.go
@@ -1,0 +1,132 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/strangelove-ventures/lens/cmd"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/rpc/client/mocks"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+func TestTendermintBlock_SpecificHeight(t *testing.T) {
+	t.Parallel()
+
+	sys := NewSystem(t)
+
+	mockBlock := coretypes.ResultBlock{
+		BlockID: types.BlockID{
+			Hash: bytes.HexBytes{0, 0, 0, 0},
+			PartSetHeader: types.PartSetHeader{
+				Total: 1234,
+				Hash:  bytes.HexBytes{1, 1, 1, 1},
+			},
+		},
+		// Partially populated block just to confirm data flows through.
+		Block: &types.Block{
+			Header: types.Header{
+				ChainID: "cosmoshub",
+				Height:  100,
+				Time:    time.Now().Add(-time.Second),
+			},
+		},
+	}
+	mc := new(mocks.Client)
+	expHeight := new(int64)
+	*expHeight = 100
+	mc.On("Block", mock.Anything, expHeight).Return(&mockBlock, nil)
+
+	sys.OverrideClients("cosmoshub", cmd.ClientOverrides{
+		RPCClient: mc,
+	})
+
+	// tm status prints the received block as JSON.
+	// Nothing should output on stderr.
+	res := sys.MustRun(t, "tendermint", "block", "--height=100")
+	require.Empty(t, res.Stderr.String())
+
+	var gotBlock coretypes.ResultBlock
+	require.NoError(t, json.Unmarshal(res.Stdout.Bytes(), &gotBlock))
+
+	require.Empty(
+		t,
+		cmp.Diff(
+			mockBlock,
+			gotBlock,
+			cmpopts.IgnoreUnexported(types.Block{}, types.Data{}, types.EvidenceData{}),
+			cmpopts.EquateEmpty(),
+		),
+	)
+}
+
+func TestTendermintTx(t *testing.T) {
+	t.Parallel()
+
+	sys := NewSystem(t)
+
+	mockTx := coretypes.ResultTx{
+		Hash:   bytes.HexBytes{0x12, 0x34},
+		Height: 100,
+		Index:  5,
+		Tx:     []byte("some tx"),
+	}
+	mc := new(mocks.Client)
+	mc.On("Tx", mock.Anything, []byte{0x12, 0x34}, false).Return(&mockTx, nil)
+
+	sys.OverrideClients("cosmoshub", cmd.ClientOverrides{
+		RPCClient: mc,
+	})
+
+	// tm status prints the received tx as JSON.
+	// Nothing should output on stderr.
+	res := sys.MustRun(t, "tendermint", "tx", "1234")
+	require.Empty(t, res.Stderr.String())
+
+	var gotTx coretypes.ResultTx
+	require.NoError(t, json.Unmarshal(res.Stdout.Bytes(), &gotTx))
+
+	require.Empty(t, cmp.Diff(mockTx, gotTx, cmpopts.EquateEmpty()))
+}
+
+func TestTendermintStatus(t *testing.T) {
+	t.Parallel()
+
+	sys := NewSystem(t)
+
+	// Arbitrary status response with a few fields filled in.
+	mockStatus := coretypes.ResultStatus{
+		NodeInfo: p2p.DefaultNodeInfo{
+			Moniker: "foo bar",
+		},
+		SyncInfo: coretypes.SyncInfo{
+			LatestBlockHeight: 123,
+		},
+		ValidatorInfo: coretypes.ValidatorInfo{
+			VotingPower: 5,
+		},
+	}
+	mc := new(mocks.Client)
+	mc.On("Status", mock.Anything).Return(&mockStatus, nil)
+
+	sys.OverrideClients("cosmoshub", cmd.ClientOverrides{
+		RPCClient: mc,
+	})
+
+	// tm status prints the received status as JSON.
+	// Nothing should output on stderr.
+	res := sys.MustRun(t, "tendermint", "status")
+	require.Empty(t, res.Stderr.String())
+
+	var gotStatus coretypes.ResultStatus
+	require.NoError(t, json.Unmarshal(res.Stdout.Bytes(), &gotStatus))
+
+	require.Empty(t, cmp.Diff(mockStatus, gotStatus, cmpopts.EquateEmpty()))
+}


### PR DESCRIPTION
This introduces a way to inject mock RPC clients for testing commands
that expect to interact over RPC, without actually connecting to an RPC
server.