### PR TITLE
wire up the `--coin-type` flag in the key cmds

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -28,16 +28,16 @@ func (cc *ChainClient) KeystoreCreated(path string) bool {
 	return true
 }
 
-func (cc *ChainClient) AddKey(name string) (output *KeyOutput, err error) {
-	ko, err := cc.KeyAddOrRestore(name, 118)
+func (cc *ChainClient) AddKey(name string, coinType uint32) (output *KeyOutput, err error) {
+	ko, err := cc.KeyAddOrRestore(name, coinType)
 	if err != nil {
 		return nil, err
 	}
 	return ko, nil
 }
 
-func (cc *ChainClient) RestoreKey(name, mnemonic string) (address string, err error) {
-	ko, err := cc.KeyAddOrRestore(name, 118, mnemonic)
+func (cc *ChainClient) RestoreKey(name, mnemonic string, coinType uint32) (address string, err error) {
+	ko, err := cc.KeyAddOrRestore(name, coinType, mnemonic)
 	if err != nil {
 		return "", err
 	}

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -12,6 +12,8 @@ func TestKeyRestore(t *testing.T) {
 	keyName := "test_key"
 	mnemonic := "blind master acoustic speak victory lend kiss grab glad help demand hood roast zone lend sponsor level cheap truck kingdom apology token hover reunion"
 	expectedAddress := "cosmos15cw268ckjj2hgq8q3jf68slwjjcjlvxy57je2u"
+	var coinType uint32
+	coinType = 118 // Cosmos coin type used in address derivation
 
 	homepath := t.TempDir()
 	cl, err := client.NewChainClient(
@@ -23,7 +25,7 @@ func TestKeyRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = cl.DeleteKey(keyName) // Delete if test is being run again
-	address, err := cl.RestoreKey(keyName, mnemonic)
+	address, err := cl.RestoreKey(keyName, mnemonic, coinType)
 	if err != nil {
 		t.Fatalf("Error while restoring mnemonic: %v", err)
 	}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -68,7 +68,12 @@ $ %s k a osmo_key --chain osmosis`, appName, appName, appName)),
 				return errKeyExists(keyName)
 			}
 
-			ko, err := cl.AddKey(keyName)
+			coinType, err := cmd.Flags().GetUint32(flagCoinType)
+			if err != nil {
+				return err
+			}
+
+			ko, err := cl.AddKey(keyName, coinType)
 			if err != nil {
 				return err
 			}
@@ -84,7 +89,6 @@ $ %s k a osmo_key --chain osmosis`, appName, appName, appName)),
 			return nil
 		},
 	}
-	// TODO: wire this up
 	cmd.Flags().Uint32(flagCoinType, defaultCoinType, "coin type number for HD derivation")
 
 	return cmd
@@ -113,7 +117,12 @@ $ %s k r --chain ibc-1 faucet-key`, appName, appName)),
 				return fmt.Errorf("failed to read mnemonic: %w", err)
 			}
 
-			address, err := cl.RestoreKey(keyName, string(mnemonic))
+			coinType, err := cmd.Flags().GetUint32(flagCoinType)
+			if err != nil {
+				return err
+			}
+
+			address, err := cl.RestoreKey(keyName, string(mnemonic), coinType)
 			if err != nil {
 				return err
 			}
@@ -122,7 +131,6 @@ $ %s k r --chain ibc-1 faucet-key`, appName, appName)),
 			return nil
 		},
 	}
-	// TODO: wire this up
 	cmd.Flags().Uint32(flagCoinType, defaultCoinType, "coin type number for HD derivation")
 	return cmd
 }


### PR DESCRIPTION
The commands for adding and restoring keys has a `--coin-type` flag which is not actually wired up to the key management methods on `ChainClient`

Closes #127 