### PR TITLE
Always calling done when signing a message

### DIFF
--- a/client/tx.go
+++ b/client/tx.go
@@ -83,6 +83,7 @@ func (cc *ChainClient) SendMsgs(ctx context.Context, msgs []sdk.Msg) (*sdk.TxRes
 
 	err = func() error {
 		done := cc.SetSDKContext()
+		// ensure that we allways call done, even in case of an error or panic
 		defer done()
 		if err = tx.Sign(txf, cc.Config.Key, txb, false); err != nil {
 			return err


### PR DESCRIPTION
# Background

If `tx.Sign` returns an error, then we will never release a lock and will end up blocking the whole time. This piece of code ensures that we always call done which will release a lock (even if`tx.Sign` panics).

# Testing completed

- running tests `go test -v ./...` with a success