### PR TITLE
Add functions for querying txs and wire up `QueryTx` to the cli cmd

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -2,7 +2,11 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -212,6 +216,37 @@ func (cc *ChainClient) QueryTotalSupply(ctx context.Context, pageReq *query.Page
 
 func (cc *ChainClient) QueryDenomsMetadata(ctx context.Context, pageReq *query.PageRequest) (*bankTypes.QueryDenomsMetadataResponse, error) {
 	return bankTypes.NewQueryClient(cc).DenomsMetadata(ctx, &bankTypes.QueryDenomsMetadataRequest{Pagination: pageReq})
+}
+
+// QueryTx takes a hex encoded tx hash and decodes it before attempting to query the tx via the RPCClient.
+func (cc *ChainClient) QueryTx(ctx context.Context, hashHex string, prove bool) (*ctypes.ResultTx, error) {
+	hash, err := hex.DecodeString(hashHex)
+	if err != nil {
+		return nil, err
+	}
+
+	return cc.RPCClient.Tx(ctx, hash, prove)
+}
+
+// QueryTxs returns an array of transactions related to the specified event search criteria.
+func (cc *ChainClient) QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error) {
+	if len(events) == 0 {
+		return nil, errors.New("must declare at least one event to search")
+	}
+
+	if page <= 0 {
+		return nil, errors.New("page must greater than 0")
+	}
+
+	if limit <= 0 {
+		return nil, errors.New("limit must greater than 0")
+	}
+
+	res, err := cc.RPCClient.TxSearch(ctx, strings.Join(events, " AND "), true, &page, &limit, "")
+	if err != nil {
+		return nil, err
+	}
+	return res.Txs, nil
 }
 
 func DefaultPageRequest() *query.PageRequest {

--- a/client/query.go
+++ b/client/query.go
@@ -5,8 +5,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"strings"
+
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"

--- a/cmd/tendermint.go
+++ b/cmd/tendermint.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/hex"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -390,14 +389,12 @@ func queryTxCmd(a *appState) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			h, err := hex.DecodeString(args[0])
+
+			block, err := cl.QueryTx(cmd.Context(), args[0], prove)
 			if err != nil {
 				return err
 			}
-			block, err := cl.RPCClient.Tx(cmd.Context(), h, prove)
-			if err != nil {
-				return err
-			}
+
 			return cl.PrintObject(block)
 		},
 	}


### PR DESCRIPTION
Querying tx information is likely to be a desired use-case in client development when using `lens`

This PR adds functions for querying txs from the Tendermint RPC endpoint