### PR TITLE
Use configured `ChainClient` key in tx simulation

### DIFF
--- a/client/tx.go
+++ b/client/tx.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -179,10 +178,15 @@ func (cc *ChainClient) PrepareFactory(txf tx.Factory) (tx.Factory, error) {
 }
 
 func (cc *ChainClient) CalculateGas(ctx context.Context, txf tx.Factory, msgs ...sdk.Msg) (txtypes.SimulateResponse, uint64, error) {
+	keyInfo, err := cc.Keybase.Key(cc.Config.Key)
+	if err != nil {
+		return txtypes.SimulateResponse{}, 0, err
+	}
+
 	var txBytes []byte
 	if err := retry.Do(func() error {
 		var err error
-		txBytes, err = BuildSimTx(cc.Keybase, txf, msgs...)
+		txBytes, err = BuildSimTx(keyInfo, txf, msgs...)
 		if err != nil {
 			return err
 		}
@@ -280,22 +284,15 @@ type protoTxProvider interface {
 
 // BuildSimTx creates an unsigned tx with an empty single signature and returns
 // the encoded transaction or an error if the unsigned transaction cannot be built.
-func BuildSimTx(keybase keyring.Keyring, txf tx.Factory, msgs ...sdk.Msg) ([]byte, error) {
+func BuildSimTx(info keyring.Info, txf tx.Factory, msgs ...sdk.Msg) ([]byte, error) {
 	txb, err := tx.BuildUnsignedTx(txf, msgs...)
 	if err != nil {
 		return nil, err
 	}
 
 	var pk cryptotypes.PubKey = &secp256k1.PubKey{} // use default public key type
-	if keybase != nil {
-		infos, _ := keybase.List()
-		if len(infos) == 0 {
-			return nil, errors.New("cannot build signature for simulation, key infos slice is empty")
-		}
 
-		// take the first info record just for simulation purposes
-		pk = infos[0].GetPubKey()
-	}
+	pk = info.GetPubKey()
 
 	// Create an empty signature literal as the ante handler will populate with a
 	// sentinel pubkey.


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR fixes a bug in tx simulation that would present itself in testing due to how the keystore was managed. Instead of trying to read an arbitrary key to get the PubKey details we retrieve the key information for the calling chain's configured key.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Testing

There are no specific test cases in the relayer for Evmos and adding some to the relayer is probably more effort than it's worth since we will be ditching the included integration tests in favor of `ibctest`. Ideally we test EVM based chains in `ibctest` but that is outside the scope of this work.

- Checkout the relayer at https://github.com/cosmos/relayer/pull/779
- Run `make test-integration`

The tests should all run to completion and pass; before this fix you would see errors like the following
```
logger.go:130: 2022-06-07T10:52:12.157-0500 INFO    Error building or broadcasting transaction      {"chain_id": "ibc-1", "attempt": 1, "max_attempts": 5, "error": "cannot build signature for simulation, key infos slice is empty"}
```


