### PR TITLE
Allow height to be supplied to dynamic queries

### DIFF
--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -173,7 +173,7 @@ func dynamicQuery(cmd *cobra.Command, a *appState, gRPCAddr, serviceName, method
 
 	md := metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
 	ctx := metadata.NewOutgoingContext(cmd.Context(), md)
-	output, err := dynClient.InvokeRpc(ctx, methodDesc, inputMsg, )
+	output, err := dynClient.InvokeRpc(ctx, methodDesc, inputMsg)
 	if err != nil {
 		return fmt.Errorf("failed to invoke rpc: %w", err)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

Allow a user to specify the height at which the query is performed

```
$ ./build/lens dynamic query osmosis osmosis.gamm.v1beta1.Query Pool '{ "poolId": "678" }' --height 4741243 | jq
{
  "pool": {
    "@type": "/osmosis.gamm.v1beta1.Pool",
    "address": "osmo10venxtvdglryxkdmvjr8wa6n3ugja40rewddlxtg0pr30vmkf47sllgslg",
    "futurePoolGovernor": "24h",
    "id": "678",
    "poolAssets": [
      {
        "token": {
          "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
          "amount": "11592143478966"
        },
        "weight": "536870912000000"
      },
      {
        "token": {
          "denom": "uosmo",
          "amount": "14754255690072"
        },
        "weight": "536870912000000"
      }
    ],
    "poolParams": {
      "swapFee": "2000000000000000",
      "exitFee": "0"
    },
    "totalShares": {
      "denom": "gamm/pool/678",
      "amount": "2938166961742364582424516"
    },
    "totalWeight": "1073741824000000"
  }
}
```

