### PR TITLE
fix: use sdk-go v1.42.4-lens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/strangelove-ventures/lens
 go 1.18
 
 require (
-	github.com/InjectiveLabs/sdk-go v1.42.3
+	github.com/InjectiveLabs/sdk-go v1.42.4-lens
 	github.com/avast/retry-go/v4 v4.1.0
 	github.com/cosmos/cosmos-sdk v0.46.0
 	github.com/cosmos/go-bip39 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5H
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.1.0/go.mod h1:LGOGuvEgCfCQsy3JF2tRmpGDpzA53iZfyGEWSPwQ6/4=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
-github.com/InjectiveLabs/sdk-go v1.42.3 h1:bumPgSCScsxnDe/zN1g+TxcR24Hf1TjHsszmIgU9nRI=
-github.com/InjectiveLabs/sdk-go v1.42.3/go.mod h1:m0gz2qvt7HnLiYLm8FA3BUlTuy9WDjoaT9yA2J2mK0I=
+github.com/InjectiveLabs/sdk-go v1.42.4-lens h1:90uImanXE/+AOwbq1geijvvvyNgUiEUvjyWC0W98D9Y=
+github.com/InjectiveLabs/sdk-go v1.42.4-lens/go.mod h1:gVKlyJDwXQz4PR7QkOITbF89it2FVcB4ifRkP1hH/7k=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=


### PR DESCRIPTION
Removes amino.Seal call in codec init. Not sure if this will work, but worth a shot. 