### PR TITLE
Fix account sequence mismatch errors

### DIFF
--- a/client/chain_client.go
+++ b/client/chain_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -43,6 +44,7 @@ type ChainClient struct {
 	// TODO: GRPC Client type?
 
 	Codec Codec
+	txMu  sync.Mutex // safety for account sequence number
 }
 
 func NewChainClient(log *zap.Logger, ccc *ChainClientConfig, homepath string, input io.Reader, output io.Writer, kro ...keyring.Option) (*ChainClient, error) {

--- a/client/tx.go
+++ b/client/tx.go
@@ -171,8 +171,6 @@ func (cc *ChainClient) PrepareFactory(txf tx.Factory) (tx.Factory, error) {
 		txf = txf.WithAccountNumber(num)
 	} else if initNum != 0 {
 		txf = txf.WithAccountNumber(initNum)
-	} else {
-		return txf, fmt.Errorf("all attempts to retrieve account number returned 0")
 	}
 
 	initSeq := txf.Sequence()
@@ -180,8 +178,6 @@ func (cc *ChainClient) PrepareFactory(txf tx.Factory) (tx.Factory, error) {
 		txf = txf.WithSequence(seq)
 	} else if initSeq != 0 {
 		txf = txf.WithSequence(initSeq)
-	} else {
-		return txf, fmt.Errorf("all attempts to retrieve sequence number returned 0")
 	}
 
 	if cc.Config.MinGasAmount != 0 {

--- a/client/tx.go
+++ b/client/tx.go
@@ -54,6 +54,11 @@ func (cc *ChainClient) SendMsg(ctx context.Context, msg sdk.Msg, memo string) (*
 // of that transaction will be logged. A boolean indicating if a transaction was successfully
 // sent and executed successfully is returned.
 func (cc *ChainClient) SendMsgs(ctx context.Context, msgs []sdk.Msg, memo string) (*sdk.TxResponse, error) {
+	// Guard against account sequence number mismatch errors by locking for the specific wallet for
+	// the account sequence query all the way through the transaction broadcast success/fail.
+	cc.txMu.Lock()
+	defer cc.txMu.Unlock()
+
 	txf, err := cc.PrepareFactory(cc.TxFactory())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
While using lens for tx broadcasting in the relayer, we frequently see account mismatch errors, often repetitive with the same sequence mismatch multiple times:

```
2022-09-28T19:11:43.957745Z     info    Error building or broadcasting transaction      {"provider_type": "cosmos", "chain_id": "axelar-dojo-1", "attempt": 2, "max_attempts": 5, "error": "rpc error: code = InvalidArgument desc = account sequence mismatch, expected 10, got 9: incorrect account sequence: invalid request"}
2022-09-28T19:11:51.252966Z     info    Error building or broadcasting transaction      {"provider_type": "cosmos", "chain_id": "axelar-dojo-1", "attempt": 3, "max_attempts": 5, "error": "rpc error: code = InvalidArgument desc = account sequence mismatch, expected 10, got 9: incorrect account sequence: invalid request"}
2022-09-28T19:11:59.269768Z     info    Error building or broadcasting transaction      {"provider_type": "cosmos", "chain_id": "axelar-dojo-1", "attempt": 4, "max_attempts": 5, "error": "rpc error: code = InvalidArgument desc = account sequence mismatch, expected 10, got 9: incorrect account sequence: invalid request"}
2022-09-28T19:12:06.017468Z     info    Error building or broadcasting transaction      {"provider_type": "cosmos", "chain_id": "axelar-dojo-1", "attempt": 1, "max_attempts": 5, "error": "rpc error: code = InvalidArgument desc = account sequence mismatch, expected 10, got 9: incorrect account sequence: invalid request"}
```

After one of these account sequence errors, lens should not try to send another transaction with sequence 9, since it has already been given an error from the node that 10 is expected.

The account sequence number should be queried every time in case there are tx broadcasters for the same wallet outside of lens.

Additionally, lens can guard its own use of the wallet by using a mutex surrounding the process of:
- Query for account sequence and add to tx
- Sign tx
- Broadcast tx